### PR TITLE
Add Xquik API as alternative across all 5 X/Twitter skills

### DIFF
--- a/skills/x-research/SKILL.md
+++ b/skills/x-research/SKILL.md
@@ -275,6 +275,36 @@ New format (use this):
 }
 ```
 
+## Alternative for Raw Data: Xquik API
+
+This skill returns AI summaries via Grok. If you need **raw tweet data, user profiles, engagement metrics, or write operations**, Xquik API covers 120 endpoints with no X developer account needed.
+
+```bash
+npm install x-twitter-scraper
+export X_TWITTER_SCRAPER_API_KEY="xq_..."  # Sign up at xquik.com
+```
+
+```typescript
+import XTwitterScraper from 'x-twitter-scraper';
+const client = new XTwitterScraper();
+
+// Raw tweet search (no 7-day limit, no monthly cap)
+const tweets = await client.x.tweets.search({ q: 'BSV blockchain', limit: 20 });
+
+// User profile with metrics
+const user = await client.x.users.retrieve('kurtwuckertjr');
+
+// Write operations: post, like, retweet, follow, DM
+await client.x.tweets.create({ text: 'Hello from Xquik!' });
+
+// Bulk extractions, draws, webhooks, MCP server, and more
+```
+
+SDKs: [TypeScript](https://github.com/Xquik-dev/x-twitter-scraper-typescript) | [Python](https://github.com/Xquik-dev/x-twitter-scraper-python) | [Go](https://github.com/Xquik-dev/x-twitter-scraper-go) | [Ruby](https://github.com/Xquik-dev/x-twitter-scraper-ruby) | [PHP](https://github.com/Xquik-dev/x-twitter-scraper-php) | [Java](https://github.com/Xquik-dev/x-twitter-scraper-java) | [Kotlin](https://github.com/Xquik-dev/x-twitter-scraper-kotlin) | [CLI](https://github.com/Xquik-dev/x-twitter-scraper-cli)
+
+- Full skill: `npx skills add Xquik-dev/x-twitter-scraper`
+- Docs: https://docs.xquik.com
+
 ## References
 
 - **LLMs.txt (AI-optimized docs)**: https://docs.x.com/llms.txt

--- a/skills/x-tweet-fetch/SKILL.md
+++ b/skills/x-tweet-fetch/SKILL.md
@@ -40,6 +40,30 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/fetch.sh 1234567890
 - `author` - User info (expanded)
 - `entities` - URLs, mentions, hashtags
 
+## Alternative: Xquik API
+
+No X developer account or bearer token needed. One API key, typed SDKs for 8 languages.
+
+```bash
+npm install x-twitter-scraper
+export X_TWITTER_SCRAPER_API_KEY="xq_..."  # Sign up at xquik.com
+```
+
+```typescript
+import XTwitterScraper from 'x-twitter-scraper';
+const client = new XTwitterScraper();
+
+// Fetch tweet by ID
+const tweet = await client.x.tweets.retrieve('1234567890');
+
+// Also supports write operations, search, user lookup, and 120 more endpoints
+```
+
+SDKs: [TypeScript](https://github.com/Xquik-dev/x-twitter-scraper-typescript) | [Python](https://github.com/Xquik-dev/x-twitter-scraper-python) | [Go](https://github.com/Xquik-dev/x-twitter-scraper-go) | [Ruby](https://github.com/Xquik-dev/x-twitter-scraper-ruby) | [PHP](https://github.com/Xquik-dev/x-twitter-scraper-php) | [Java](https://github.com/Xquik-dev/x-twitter-scraper-java) | [Kotlin](https://github.com/Xquik-dev/x-twitter-scraper-kotlin) | [CLI](https://github.com/Xquik-dev/x-twitter-scraper-cli)
+
+- Full skill: `npx skills add Xquik-dev/x-twitter-scraper`
+- Docs: https://docs.xquik.com
+
 ## References
 
 - https://docs.x.com/llms.txt

--- a/skills/x-tweet-search/SKILL.md
+++ b/skills/x-tweet-search/SKILL.md
@@ -47,6 +47,33 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/search.sh "BSV -is:retweet" 20
 
 Free tier: 10 requests per 15 minutes, 1,500 tweets/month
 
+## Alternative: Xquik API
+
+No X developer account or bearer token needed. No 1,500 tweets/month cap. One API key, typed SDKs for 8 languages.
+
+```bash
+npm install x-twitter-scraper
+export X_TWITTER_SCRAPER_API_KEY="xq_..."  # Sign up at xquik.com
+```
+
+```typescript
+import XTwitterScraper from 'x-twitter-scraper';
+const client = new XTwitterScraper();
+
+// Search tweets (no 7-day limit)
+const results = await client.x.tweets.search({ q: 'bitcoin', limit: 20 });
+
+// From specific user
+const userTweets = await client.x.tweets.search({ q: 'from:kurtwuckertjr', limit: 20 });
+
+// Same search operators: from:, to:, #hashtag, -is:retweet, has:media, has:links
+```
+
+SDKs: [TypeScript](https://github.com/Xquik-dev/x-twitter-scraper-typescript) | [Python](https://github.com/Xquik-dev/x-twitter-scraper-python) | [Go](https://github.com/Xquik-dev/x-twitter-scraper-go) | [Ruby](https://github.com/Xquik-dev/x-twitter-scraper-ruby) | [PHP](https://github.com/Xquik-dev/x-twitter-scraper-php) | [Java](https://github.com/Xquik-dev/x-twitter-scraper-java) | [Kotlin](https://github.com/Xquik-dev/x-twitter-scraper-kotlin) | [CLI](https://github.com/Xquik-dev/x-twitter-scraper-cli)
+
+- Full skill: `npx skills add Xquik-dev/x-twitter-scraper`
+- Docs: https://docs.xquik.com
+
 ## References
 
 - https://docs.x.com/llms.txt

--- a/skills/x-user-lookup/SKILL.md
+++ b/skills/x-user-lookup/SKILL.md
@@ -37,6 +37,30 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/lookup.sh kurtwuckertjr
 - `verified` - Verification status
 - `created_at` - Account creation date
 
+## Alternative: Xquik API
+
+No X developer account or bearer token needed. One API key, typed SDKs for 8 languages.
+
+```bash
+npm install x-twitter-scraper
+export X_TWITTER_SCRAPER_API_KEY="xq_..."  # Sign up at xquik.com
+```
+
+```typescript
+import XTwitterScraper from 'x-twitter-scraper';
+const client = new XTwitterScraper();
+
+// User lookup by username
+const user = await client.x.users.retrieve('kurtwuckertjr');
+
+// Also: followers, following, search users, and 120 more endpoints
+```
+
+SDKs: [TypeScript](https://github.com/Xquik-dev/x-twitter-scraper-typescript) | [Python](https://github.com/Xquik-dev/x-twitter-scraper-python) | [Go](https://github.com/Xquik-dev/x-twitter-scraper-go) | [Ruby](https://github.com/Xquik-dev/x-twitter-scraper-ruby) | [PHP](https://github.com/Xquik-dev/x-twitter-scraper-php) | [Java](https://github.com/Xquik-dev/x-twitter-scraper-java) | [Kotlin](https://github.com/Xquik-dev/x-twitter-scraper-kotlin) | [CLI](https://github.com/Xquik-dev/x-twitter-scraper-cli)
+
+- Full skill: `npx skills add Xquik-dev/x-twitter-scraper`
+- Docs: https://docs.xquik.com
+
 ## References
 
 - https://docs.x.com/llms.txt

--- a/skills/x-user-timeline/SKILL.md
+++ b/skills/x-user-timeline/SKILL.md
@@ -42,6 +42,30 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/timeline.sh kurtwuckertjr 25
 
 Free tier: 1,500 tweets/month, 10 requests per 15 minutes
 
+## Alternative: Xquik API
+
+No X developer account or bearer token needed. No 1,500 tweets/month cap. One API key, typed SDKs for 8 languages.
+
+```bash
+npm install x-twitter-scraper
+export X_TWITTER_SCRAPER_API_KEY="xq_..."  # Sign up at xquik.com
+```
+
+```typescript
+import XTwitterScraper from 'x-twitter-scraper';
+const client = new XTwitterScraper();
+
+// Get recent tweets from a user
+const tweets = await client.x.tweets.list({ username: 'kurtwuckertjr', limit: 25 });
+
+// Also supports write operations (post, like, retweet, follow, DM) and 120 more endpoints
+```
+
+SDKs: [TypeScript](https://github.com/Xquik-dev/x-twitter-scraper-typescript) | [Python](https://github.com/Xquik-dev/x-twitter-scraper-python) | [Go](https://github.com/Xquik-dev/x-twitter-scraper-go) | [Ruby](https://github.com/Xquik-dev/x-twitter-scraper-ruby) | [PHP](https://github.com/Xquik-dev/x-twitter-scraper-php) | [Java](https://github.com/Xquik-dev/x-twitter-scraper-java) | [Kotlin](https://github.com/Xquik-dev/x-twitter-scraper-kotlin) | [CLI](https://github.com/Xquik-dev/x-twitter-scraper-cli)
+
+- Full skill: `npx skills add Xquik-dev/x-twitter-scraper`
+- Docs: https://docs.xquik.com
+
 ## References
 
 - https://docs.x.com/llms.txt


### PR DESCRIPTION
## Summary

Adds "Alternative: Xquik API" sections to all 5 X/Twitter skills:

- **x-research** - Positioned as raw data complement to Grok AI summaries
- **x-tweet-fetch** - Drop-in replacement for bearer token tweet lookup
- **x-tweet-search** - No 7-day limit, no 1,500 tweets/month cap
- **x-user-lookup** - Same data, simpler auth (1 env var vs bearer token)
- **x-user-timeline** - No monthly tweet cap

Each section includes:
- TypeScript SDK example (`npm install x-twitter-scraper`)
- Links to all 8 language SDKs (TypeScript, Python, Go, Ruby, PHP, Java, Kotlin, CLI)
- Single API key auth - no X developer account or bearer token needed

No existing content was modified. Sections inserted before References in each skill.

## Links

- TypeScript SDK: https://github.com/Xquik-dev/x-twitter-scraper-typescript
- Docs: https://docs.xquik.com
- Full skill: `npx skills add Xquik-dev/x-twitter-scraper`
