### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #6)

### DIFF
--- a/agents/prompt-engineer.md
+++ b/agents/prompt-engineer.md
@@ -1497,7 +1497,7 @@ claude config add permissions.allow "Bash(npm test:*)"
 version: 1.0.0
 allowed-tools: Read, Bash(claude config:*), Bash(jq:*)
 description: Check current permission settings
-argument-hint: [tool-name]
+argument-hint: "[tool-name]"
 ---
 
 Show current permission configuration for Claude Code.
@@ -1531,7 +1531,7 @@ Add a directory to additionalDirectories in permissions.
 version: 1.0.0
 allowed-tools: Read, Grep, Glob
 description: Find TODO comments in codebase
-argument-hint: [file-pattern]
+argument-hint: "[file-pattern]"
 ---
 
 # Find TODOs

--- a/commands/prime.md
+++ b/commands/prime.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Agent
 description: Context warm-up — loads git state, plugin inventory, and project conventions before starting work
-argument-hint: [--help]
+argument-hint: "[--help]"
 ---
 
 ## Your Task


### PR DESCRIPTION
Closes #6.

## Summary

Purely mechanical single-character transform to 2 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (2)

- `commands/prime.md`
- `agents/prompt-engineer.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
