### PR TITLE
Add shadscan skill and wire it into the shadcn agent line

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bopen-tools",
-  "version": "1.1.110",
+  "version": "1.1.111",
   "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code and Codex",
   "author": {
     "name": "b-open-io",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bopen-tools",
-  "version": "1.1.110",
+  "version": "1.1.111",
   "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code and Codex",
   "author": {
     "name": "b-open-io",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ manifests share the same release version.
 
 ## Unreleased
 
+## [1.1.111] - 2026-07-24
+
+### Added
+
+- `shadscan` (1.0.0): new skill that drives the `@shadscan/cli` static analyzer
+  through an audit → fix → re-score loop against shadcn/React apps, covering the
+  six scored categories (foundation, interaction, states, accessibility, forms,
+  production-polish), the AI-agent handoff modes (`--format prompt`,
+  `--apply --agent claude`), and the CI score gate (`--fail-under`, GitHub
+  Action, pre-commit). Deep flag reference, JSON notes, and a per-category fix
+  playbook live in `references/reference.md`.
+
+### Changed
+
+- `designer` (Ridd, 1.0.22), `nextjs` (Theo, 1.1.10), and `tester` (Jason,
+  1.3.17): wired the new `shadscan` skill into the shadcn-capable line with a
+  maker/checker split — Ridd is the primary fixer (categories map onto his
+  accessibility/states/forms patterns), Theo the secondary fixer for structural
+  and composition findings, and Jason owns the CI `--fail-under` gate rather
+  than applying UI fixes.
+
 ## [1.1.110] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ bunx skills add b-open-io/bopen-tools --skill runtime-context
 bunx skills add b-open-io/bopen-tools --skill saas-launch-audit
 bunx skills add b-open-io/bopen-tools --skill setup
 bunx skills add b-open-io/bopen-tools --skill shaders
+bunx skills add b-open-io/bopen-tools --skill shadscan
 bunx skills add b-open-io/bopen-tools --skill skill-publish
 bunx skills add b-open-io/bopen-tools --skill software-factory
 bunx skills add b-open-io/bopen-tools --skill statusline-setup
@@ -296,6 +297,7 @@ intentional.
 | `paperclip-plugin-dev` | Build and review Paperclip plugins against the worker and UI contracts |
 | `perf-audit` | Run local performance audits without network calls |
 | `shaders` | Custom shaders for Three.js and WebGL |
+| `shadscan` | Drive the shadscan analyzer to audit and raise a shadcn app's UI-fundamentals score, and gate it in CI |
 | `software-factory` | Design autonomous agent workflows with a real verification gate, bounded state, and stop conditions |
 | `threejs-r3f` | Building Three.js and React Three Fiber projects |
 | `visual-review` | Turn a PR, branch, or diff into a visual HTML review page |

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -34,11 +34,12 @@ skills:
   - document-skills:pdf
   - html-to-pdf
   - bopen-tools:design-game-ui
+  - bopen-tools:shadscan
 icon: https://bopen.ai/images/agents/ridd.png
-version: 1.0.21
+version: 1.0.22
 model: sonnet
 description: Creates beautiful, accessible UI components and directional interfaces using modern design systems and frameworks. This agent should be used when the user asks to "design a component", "create UI", "style a page", "set up shadcn", "implement dark mode", "review UI accessibility", "design in pencil", "create a mockup", "design a game HUD", "build a TV app interface", "add controller navigation", "plan TV remote focus", "design ten-foot UI", or "turn this app into a game UI".
-tools: ["Read", "Write", "Edit", "WebFetch", "Bash", "Grep", "Glob", "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "Skill(vercel-react-best-practices)", "Skill(web-design-guidelines)", "Skill(frontend-design)", "Skill(ui-audio-theme)", "Skill(gemskills:deck-creator)", "Skill(gemskills:generate-image)", "Skill(gemskills:generate-svg)", "Skill(gemskills:generate-icon)", "Skill(gemskills:edit-image)", "Skill(gemskills:optimize-images)", "Skill(gemskills:section-dividers)", "Skill(gemskills:browsing-styles)", "Skill(gemskills:avatar-portrait)", "Skill(gemskills:ask-gemini)", "Skill(gemskills:generate-video)", "Skill(gemskills:upscale-image)", "Skill(gemskills:segment-image)", "Skill(bopen-tools:generative-ui)", "Skill(bopen-tools:mcp-apps)", "Skill(superpowers:dispatching-parallel-agents)", "Skill(superpowers:subagent-driven-development)", "Skill(agent-browser)", "Skill(chrome-cdp)", "mcp__pencil__get_editor_state", "mcp__pencil__open_document", "mcp__pencil__get_guidelines", "mcp__pencil__get_style_guide_tags", "mcp__pencil__get_style_guide", "mcp__pencil__batch_get", "mcp__pencil__batch_design", "mcp__pencil__snapshot_layout", "mcp__pencil__get_screenshot", "mcp__pencil__get_variables", "mcp__pencil__set_variables", "mcp__pencil__find_empty_space_on_canvas", "mcp__pencil__search_all_unique_properties", "mcp__pencil__replace_all_matching_properties", "Skill(gemskills:pixel-avatar)", "Skill(gemskills:style-creator)", "Skill(gemskills:team-group-photo)", "Skill(shadcn)", "Skill(document-skills:pdf)", "Skill(html-to-pdf)", "Skill(bopen-tools:design-game-ui)"]
+tools: ["Read", "Write", "Edit", "WebFetch", "Bash", "Grep", "Glob", "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "Skill(vercel-react-best-practices)", "Skill(web-design-guidelines)", "Skill(frontend-design)", "Skill(ui-audio-theme)", "Skill(gemskills:deck-creator)", "Skill(gemskills:generate-image)", "Skill(gemskills:generate-svg)", "Skill(gemskills:generate-icon)", "Skill(gemskills:edit-image)", "Skill(gemskills:optimize-images)", "Skill(gemskills:section-dividers)", "Skill(gemskills:browsing-styles)", "Skill(gemskills:avatar-portrait)", "Skill(gemskills:ask-gemini)", "Skill(gemskills:generate-video)", "Skill(gemskills:upscale-image)", "Skill(gemskills:segment-image)", "Skill(bopen-tools:generative-ui)", "Skill(bopen-tools:mcp-apps)", "Skill(superpowers:dispatching-parallel-agents)", "Skill(superpowers:subagent-driven-development)", "Skill(agent-browser)", "Skill(chrome-cdp)", "mcp__pencil__get_editor_state", "mcp__pencil__open_document", "mcp__pencil__get_guidelines", "mcp__pencil__get_style_guide_tags", "mcp__pencil__get_style_guide", "mcp__pencil__batch_get", "mcp__pencil__batch_design", "mcp__pencil__snapshot_layout", "mcp__pencil__get_screenshot", "mcp__pencil__get_variables", "mcp__pencil__set_variables", "mcp__pencil__find_empty_space_on_canvas", "mcp__pencil__search_all_unique_properties", "mcp__pencil__replace_all_matching_properties", "Skill(gemskills:pixel-avatar)", "Skill(gemskills:style-creator)", "Skill(gemskills:team-group-photo)", "Skill(shadcn)", "Skill(document-skills:pdf)", "Skill(html-to-pdf)", "Skill(bopen-tools:design-game-ui)", "Skill(bopen-tools:shadscan)"]
 color: magenta
 ---
 
@@ -310,6 +311,19 @@ For consistent multi-generation outputs, commit to a specific aesthetic:
 Always implement: hover, focus, active, disabled, loading, error
 
 ## shadcn/ui Patterns
+
+### Auditing with shadscan (score your shadcn work)
+
+You are the **primary fixer** for `shadscan` — a deterministic static analyzer
+that grades shadcn/React UIs `0–100` across `foundation`, `interaction`,
+`states`, `accessibility`, `forms`, and `production-polish`. Those categories
+map almost 1:1 onto your Accessibility Checklist, States list, and Form pattern.
+Invoke `Skill(bopen-tools:shadscan)` and run the audit → fix → re-score loop:
+baseline with `npx @shadscan/cli <path> --json`, pull the agent handoff with
+`--format prompt`, fix the lowest category first, re-scan the touched path, and
+report the before → after delta. Hand structural/composition/data-bound findings
+to **Theo** (`nextjs`); the CI `--fail-under` gate belongs to **Jason**
+(`tester`), not you.
 
 ### shadcn/ui CLI v4
 

--- a/agents/nextjs.md
+++ b/agents/nextjs.md
@@ -16,8 +16,9 @@ skills:
   - bopen-tools:nextjs-upgrade
   - shadcn
   - react-doctor
+  - bopen-tools:shadscan
 icon: https://bopen.ai/images/agents/theo.png
-version: 1.1.9
+version: 1.1.10
 description: |-
   Use this agent when the user asks to "build a Next.js page", "fix this React 19 issue", "set up Turbopack", "migrate to async APIs", or needs Next.js/React development with Vercel best practices and modern tooling (Bun, Biome). Not for React Native/mobile work (use mobile) or visual component design (use designer).
 
@@ -29,7 +30,7 @@ description: |-
   Next.js/React implementation work on the Vercel stack is Theo's core job.
   </commentary>
   </example>
-tools: Read, Write, Edit, Bash, WebFetch, Grep, Glob, TaskCreate, TaskUpdate, TaskGet, TaskList, Skill(vercel-react-best-practices), Skill(create-next-project), Skill(portless), Skill(agent-browser), Skill(simplify), Skill(semgrep), Skill(bopen-tools:generative-ui), Skill(superpowers:dispatching-parallel-agents), Skill(superpowers:subagent-driven-development), Skill(bopen-tools:nextjs-upgrade), Skill(shadcn), Skill(react-doctor)
+tools: Read, Write, Edit, Bash, WebFetch, Grep, Glob, TaskCreate, TaskUpdate, TaskGet, TaskList, Skill(vercel-react-best-practices), Skill(create-next-project), Skill(portless), Skill(agent-browser), Skill(simplify), Skill(semgrep), Skill(bopen-tools:generative-ui), Skill(superpowers:dispatching-parallel-agents), Skill(superpowers:subagent-driven-development), Skill(bopen-tools:nextjs-upgrade), Skill(shadcn), Skill(react-doctor), Skill(bopen-tools:shadscan)
 color: blue
 model: sonnet
 emoji: ⚡
@@ -77,6 +78,16 @@ Key rule categories (by priority):
 3. **Server-Side** (HIGH) - server-cache-react, server-parallel-fetching
 4. **Client-Side Data** (MEDIUM-HIGH) - client-swr-dedup
 5. **Re-render Optimization** (MEDIUM) - rerender-memo, rerender-derived-state
+
+## shadcn UI fundamentals (shadscan)
+
+When work touches shadcn components, you are the **secondary fixer** for
+`shadscan` — the deterministic UI-fundamentals analyzer. Own the structural,
+composition, and data-bound findings (`foundation`, `interaction`, and parts of
+`production-polish`); hand presentational accessibility/states/forms fixes to
+**Ridd** (`designer`). Invoke `Skill(bopen-tools:shadscan)` and run its audit →
+fix → re-score loop, reporting the before → after score. The CI `--fail-under`
+gate is **Jason's** (`tester`), not yours.
 
 ## Mission
 

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -18,8 +18,9 @@ skills:
   - superpowers:subagent-driven-development
   - bopen-tools:software-factory
   - bopen-tools:free-roam-testing
+  - bopen-tools:shadscan
 icon: https://bopen.ai/images/agents/jason.png
-version: 1.3.16
+version: 1.3.17
 model: sonnet
 description: |-
   Use this agent when the user asks to "write tests", "add test coverage", "set up e2e/Playwright tests", "fix failing tests", or "add a CI coverage gate", or when a change needs unit/integration/e2e tests before merging. Covers mocking, coverage analysis, and CI test automation. Not for performance profiling (use optimizer) or security review (use code-auditor).
@@ -50,7 +51,7 @@ description: |-
   CI/CD test automation and coverage reporting setup is Jason's responsibility.
   </commentary>
   </example>
-tools: Read, Write, Edit, Bash, Bash(agent-browser:*), Grep, Glob, TaskCreate, TaskUpdate, TaskGet, TaskList, Skill(visual-review), Skill(confess), Skill(portless), Skill(webapp-testing), Skill(agent-browser), Skill(chrome-cdp), Skill(skill-creator:skill-creator), Skill(bopen-tools:benchmark-skills), Skill(hunter-skeptic-referee), Skill(simplify), Skill(superpowers:dispatching-parallel-agents), Skill(superpowers:subagent-driven-development), Skill(bopen-tools:software-factory), Skill(bopen-tools:free-roam-testing)
+tools: Read, Write, Edit, Bash, Bash(agent-browser:*), Grep, Glob, TaskCreate, TaskUpdate, TaskGet, TaskList, Skill(visual-review), Skill(confess), Skill(portless), Skill(webapp-testing), Skill(agent-browser), Skill(chrome-cdp), Skill(skill-creator:skill-creator), Skill(bopen-tools:benchmark-skills), Skill(hunter-skeptic-referee), Skill(simplify), Skill(superpowers:dispatching-parallel-agents), Skill(superpowers:subagent-driven-development), Skill(bopen-tools:software-factory), Skill(bopen-tools:free-roam-testing), Skill(bopen-tools:shadscan)
 color: green
 ---
 
@@ -131,6 +132,9 @@ find . -name ".github" -o -name "gitlab-ci*" -o -name "azure-pipelines*"
 
 **IF setting up CI/CD test pipelines**
 → Read [references/tester/ci-cd.md](../references/tester/ci-cd.md) for GitHub Actions workflows, contract pipelines, reporters.
+
+**IF gating a shadcn UI on quality score**
+→ Invoke `Skill(bopen-tools:shadscan)`. You **own the gate**: add `npx @shadscan/cli . --fail-under <N> --no-interactive --no-roast` (or the shipped `.github/workflows/shadscan.yml` Action) so merges fail below the score floor. You enforce the threshold; the shadcn fixes belong to Ridd (`designer`) and Theo (`nextjs`).
 
 **IF unsure what to test or how to structure**
 → Read [references/tester/anti-patterns.md](../references/tester/anti-patterns.md) for do/avoid lists, Testing Trophy, tool preferences.

--- a/skills/shadscan/SKILL.md
+++ b/skills/shadscan/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: shadscan
+version: 1.0.0
+description: >-
+  This skill should be used when the user asks to "audit my shadcn app",
+  "run shadscan", "improve my shadscan score", "raise my shadscan grade",
+  "fix accessibility/states/forms regressions in my shadcn components", or
+  "add a shadscan CI gate". Drives the shadscan static analyzer
+  (`npx @shadscan/cli`) through an audit → fix → re-score loop against shadcn
+  React components, and wires it into CI as a score gate.
+user-invocable: true
+---
+
+# shadscan
+
+`shadscan` is a **deterministic static analyzer for shadcn/React apps**. It
+grades UI fundamentals — same result every run, built for the terminal and CI.
+Use it to measure and then *raise* the quality of shadcn components, and to gate
+merges on a minimum score.
+
+This skill is the driver. The actual fixes belong to the shadcn-capable agents
+(`designer` / Ridd, `nextjs` / Theo); this skill tells you how to run the tool,
+read the score, and loop until the grade passes.
+
+## What it scores
+
+One `0–100` score plus a letter grade, across six categories:
+
+| Category | What it inspects |
+|----------|------------------|
+| `foundation` | Base component setup, tokens, structural correctness |
+| `interaction` | Pointer/keyboard interaction wiring |
+| `states` | hover / focus / active / disabled / loading / error coverage |
+| `accessibility` | Labels, roles, ARIA, contrast, keyboard reachability |
+| `forms` | Form composition, validation, field/label association |
+| `production-polish` | Empty states, responsiveness, finishing details |
+
+## Command surface
+
+```bash
+# Audit the project (or a path). Human output with evidence + suggested fixes.
+npx @shadscan/cli [path]
+
+# Machine-readable report (schema v4) — parse this in scripts/CI.
+npx @shadscan/cli --json
+
+# Paste-ready Markdown handoff for an AI agent — THIS is the fix-loop input.
+npx @shadscan/cli --format prompt
+
+# Launch an installed coding agent directly with the findings.
+npx @shadscan/cli --apply --agent claude   # or: codex | grok
+
+# Audit one category only (tight loops).
+npx @shadscan/cli --category accessibility
+
+# CI gate: exit 1 when the score is below the floor (or can't be assessed).
+npx @shadscan/cli --fail-under 85
+
+# Neutral copy for CI/logs (disable the "roast" tone).
+npx @shadscan/cli --json --no-roast
+
+# Install a pre-commit hook that runs the scan.
+npx @shadscan/cli setup --pre-commit
+```
+
+Other flags: `--no-interactive` (skip the post-scan menu — always use this in
+scripts), `--roast` (force roast copy into JSON/CI), `--version`, `--help`.
+
+## The audit → fix → re-score loop (how to get a good score)
+
+Do not one-shot fixes and declare victory. Iterate against the tool:
+
+1. **Baseline.** Run `npx @shadscan/cli <path> --json --no-interactive` and
+   record the score, grade, and per-category breakdown. Report the number.
+2. **Get the handoff.** Run `npx @shadscan/cli <path> --format prompt` to get
+   the neutral, paste-ready findings, or scan one category with `--category`
+   to focus. The `prompt` output is written *for* an agent — feed it to the
+   fixer.
+3. **Fix by category, lowest first.** Apply changes with the shadcn patterns
+   the fixer already knows (see mapping below). Never edit
+   `components/ui/*.tsx` source directly — customize via `className`/props or
+   re-add with `shadcn@latest add <c> --overwrite`.
+4. **Re-scan only what changed.** Re-run on the touched path (or category) and
+   confirm the score moved up. If a category didn't improve, read its evidence
+   again — the tool cites exact locations.
+5. **Repeat** until the grade meets the target (or `--fail-under` passes).
+6. **Report the delta.** State before → after score and which categories moved.
+
+### Category → fixer knowledge
+
+The categories map almost 1:1 onto patterns the `designer` (Ridd) agent already
+documents — reuse them rather than inventing fixes:
+
+- `accessibility` → Ridd's Accessibility Checklist (labels, ARIA, focus order,
+  contrast ≥ 4.5:1).
+- `states` → Ridd's States list: implement hover, focus, active, disabled,
+  loading, **and** error for every interactive element.
+- `forms` → Ridd's react-hook-form + zod Form pattern (`FormField`/`FormLabel`/
+  `FormMessage` association).
+- `foundation` / `interaction` / `production-polish` → composition and
+  app-integration concerns; hand to `nextjs` (Theo) when the fix is structural
+  or data-bound, keep with Ridd when it's presentational.
+
+## Agent handoff modes
+
+- **Advisory (default in this repo):** `--format prompt` → paste the findings to
+  the fixer agent, apply, re-scan. Keeps the human/agent in control of edits.
+- **Direct:** `--apply --agent claude` launches Claude Code with the handoff.
+  Use when you want the tool to drive the agent end-to-end.
+
+## CI gate (checker-owned)
+
+The `tester` (Jason) agent owns the gate, not the fix:
+
+- **Threshold:** add `npx @shadscan/cli . --fail-under <N> --no-interactive
+  --no-roast` as a CI step. Non-zero exit fails the build.
+- **GitHub Action:** shadscan ships `.github/workflows/shadscan.yml`. Inputs:
+  `path`, `version`, `category`, `fail-under`, `create-issue`, `issue-label`,
+  `github-token`. Outputs: `score`, `grade`, `report-path` — surface these in
+  the PR.
+- **Pre-commit:** `npx @shadscan/cli setup --pre-commit` for local enforcement.
+
+See `references/reference.md` for the full flag list, JSON schema notes, a
+ready-to-drop Action workflow, and a per-category fix playbook.

--- a/skills/shadscan/references/reference.md
+++ b/skills/shadscan/references/reference.md
@@ -1,0 +1,145 @@
+# shadscan — Full Reference
+
+Deep detail for the `shadscan` skill. Load this when you need the complete flag
+surface, the CI workflow, or a per-category fix playbook. Keep the top-level
+`SKILL.md` as the day-to-day driver.
+
+## Install / invocation
+
+`shadscan` is distributed as `@shadscan/cli` and is normally run without a local
+install:
+
+```bash
+npx @shadscan/cli [path] [options]     # npm
+pnpm dlx @shadscan/cli [path] [options] # pnpm
+bunx @shadscan/cli [path] [options]     # bun
+```
+
+`[path]` defaults to the current directory. Point it at `src/components` or a
+single feature folder for tight loops.
+
+## Full flag reference
+
+| Flag | Purpose |
+|------|---------|
+| `--format <human\|json\|prompt>` | Output mode. `human` (default) prints a progress bar, per-category scores, cited evidence, and suggested fixes. `json` emits the full report (schema version 4). `prompt` emits neutral, paste-ready Markdown for an AI agent. |
+| `--json` | Shorthand for `--format json`. |
+| `--prompt` | Shorthand for `--format prompt`. |
+| `--apply` | Launch the installed coding agent with the findings handoff. |
+| `--agent <claude\|codex\|grok>` | Which agent `--apply` should launch. |
+| `--fail-under <0–100>` | Exit status `1` when the score is below the floor or cannot be assessed. Otherwise exit `0`. |
+| `--category <name>` | Audit a single category only. |
+| `--no-roast` | Neutral findings — disable "roast" copy. Use in CI/logs. |
+| `--roast` | Force roast copy into CI/JSON output. |
+| `--no-interactive` | Disable the post-scan menu. Always set this in scripts/CI. |
+| `--help` | Usage and options. |
+| `--version` | Installed CLI version. |
+
+### Subcommand
+
+```bash
+shadscan setup --pre-commit [--dry-run] [--yes]
+```
+
+Installs a pre-commit hook that runs the scan. `--dry-run` previews the change;
+`--yes` skips confirmation.
+
+## Exit codes
+
+- `0` — scan completed (findings alone do **not** fail the run).
+- `1` — with `--fail-under`, the score is below the floor or could not be
+  assessed.
+
+This is deliberate: a scan is informational until you opt into a gate. CI must
+pass `--fail-under` to enforce a threshold.
+
+## JSON report
+
+`--json` returns the complete audit report at **schema version 4**. Expect a
+top-level score and grade plus a per-category breakdown, each category carrying
+its findings with cited file locations. Parse the score/grade for gating and
+the per-category findings to route fixes. Pin the schema version you parse
+against so a future CLI bump doesn't silently change your assumptions.
+
+## Categories
+
+| Category | Focus | Typical fixes |
+|----------|-------|---------------|
+| `foundation` | Base setup, tokens, structural correctness | Use theme CSS variables (`bg-background`, `text-foreground`) not hardcoded colors; correct component composition; consistent radii/spacing tokens. |
+| `interaction` | Pointer + keyboard interaction wiring | Ensure interactive elements are real controls; keyboard operable; ESC/arrow handling on menus/dialogs. |
+| `states` | Interactive state coverage | Implement **all** of hover, focus, active, disabled, loading, error for every interactive element. Missing `loading`/`error` states are the most common point loss. |
+| `accessibility` | Labels, roles, ARIA, contrast, keyboard | Associate labels; add `aria-*` where semantics need it; visible focus indicators; contrast ≥ 4.5:1 (3:1 large text / UI); alt text. |
+| `forms` | Form composition and validation | react-hook-form + zod with `Form`/`FormField`/`FormControl`/`FormLabel`/`FormMessage`; every field has an associated label and an announced error message. |
+| `production-polish` | Finishing details | Empty states designed; responsive across mobile/tablet/desktop; no layout thrash; loading skeletons; optimized images/fonts. |
+
+## Per-category fix playbook
+
+Run `--category <name>` to isolate a category, apply the fixes below, then
+re-scan that category only. Order: fix the lowest-scoring category first.
+
+### accessibility
+1. Every interactive element gets an accessible name (visible label, `aria-label`, or `aria-labelledby`).
+2. Dialogs/menus: `aria-labelledby` + `aria-describedby`, focus trap, ESC to close, restore focus on close.
+3. Visible focus ring on all focusable elements (never `outline: none` without a replacement).
+4. Contrast: text ≥ 4.5:1, large text/UI ≥ 3:1. Fix tokens, not one-off overrides.
+
+### states
+1. For each interactive element, enumerate hover, focus, active, disabled, loading, error — implement each.
+2. Buttons that trigger async work need an explicit `loading` (disabled + spinner) and an `error` surface.
+3. Prefer shadcn/tailwind state variants (`hover:`, `focus-visible:`, `disabled:`, `aria-busy:`) over ad-hoc JS.
+
+### forms
+1. Wrap in shadcn `Form` with react-hook-form + `zodResolver`.
+2. Each input inside `FormField` → `FormItem` → `FormLabel` + `FormControl` + `FormMessage`.
+3. Errors render through `FormMessage` (announced), not a bare `<p>`.
+
+### foundation / interaction / production-polish
+1. Replace hardcoded colors with theme variables; unify radii/spacing to tokens.
+2. Make custom interactive divs into real controls (`button`, `a`, Radix/Base primitives).
+3. Add empty/loading/error surfaces and verify responsiveness; avoid CLS from unsized media.
+
+Never edit `components/ui/*.tsx` shadcn source directly — customize via
+`className`/props from the consumer, or `npx shadcn@latest add <c> --overwrite`.
+
+## GitHub Action (ready to drop)
+
+shadscan ships a reusable workflow. A minimal gate that fails PRs below a floor
+and files an issue on regression:
+
+```yaml
+# .github/workflows/shadscan.yml
+name: shadscan
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shadscan
+        id: shadscan
+        run: npx @shadscan/cli . --fail-under 85 --no-interactive --no-roast --json
+```
+
+If you prefer the packaged action (inputs `path`, `version`, `category`,
+`fail-under`, `create-issue`, `issue-label`, `github-token`; outputs `score`,
+`grade`, `report-path`), consult the shadscan docs for the exact
+`uses:` reference and pin it to a released version. Surface `score`/`grade` in
+the PR summary so reviewers see the delta.
+
+## Ownership (bopen-tools agents)
+
+- **`designer` (Ridd)** — primary fixer. Categories map onto his existing
+  Accessibility Checklist, States list, and Form pattern.
+- **`nextjs` (Theo)** — secondary fixer for structural/composition/data-bound
+  findings (`foundation`, `interaction`, parts of `production-polish`).
+- **`tester` (Jason)** — owns the CI gate: `--fail-under`, the Action, and the
+  pre-commit hook. Enforces the score; does not apply UI fixes.
+
+## Sources
+
+- https://www.shadscan.com/
+- https://www.shadscan.com/docs


### PR DESCRIPTION
shadscan (@shadscan/cli) is a deterministic static analyzer that grades
shadcn/React UIs 0-100 across foundation, interaction, states, accessibility,
forms, and production-polish. Rather than add a new agent (context waste), this
introduces one lean skill that drives the audit -> fix -> re-score loop and
attaches it to the three agents that already do shadcn work, with a maker/checker
split:

- designer (Ridd, 1.0.22): primary fixer; categories map onto his existing
  accessibility/states/forms patterns.
- nextjs (Theo, 1.1.10): secondary fixer for structural/composition findings.
- tester (Jason, 1.3.17): owns the CI --fail-under gate, not the fixes.

Skill covers the command surface, the score-raising loop, agent handoff modes
(--format prompt, --apply --agent claude), and CI gating (Action, pre-commit);
deep flag reference and per-category playbook in references/reference.md.
Bumps both plugin manifests to 1.1.111; README inventory and CHANGELOG updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016nAUQiNtmLM1zMKg7LYvC8