### PR TITLE
OPL-3602: add repo-freshness SessionStart hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Added
+
+- `repo-freshness` SessionStart hook (claude/codex/grok): non-destructively
+  keeps the active repo in sync with its remote so local checkouts don't
+  silently drift behind — e.g. behind an autonomous loop that advances origin
+  every cycle. Fast-forwards the checked-out branch when it is clean and
+  strictly behind its upstream, advances the default branch's ref when you're
+  working elsewhere, warns (never resets/rebases) on divergence, and reports
+  without touching a dirty tree. Fetches are throttled per repo; it never
+  blocks or prompts. Disable with `{"hooks": {"repo-freshness": false}}`.
+
 ### Changed
 
 - orchestra 0.1.7: `/create-workflow` is a Grok Build bundled skill at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ manifests share the same release version.
   without touching a dirty tree. Fetches are throttled per repo; it never
   blocks or prompts. Disable with `{"hooks": {"repo-freshness": false}}`.
 
+### Fixed
+
+- `session-context`: the plugin-cache mtime scan used BSD-only
+  `stat -f '%m'`, which did not cleanly fail on Linux, so the GNU `-printf`
+  fallback never ran and `printf '%.0f'` later choked on GNU stat's default
+  output. Replaced with the per-entry BSD-then-GNU fallback already used for
+  the index mtime. This was failing the `validate` CI job on every push.
+
 ### Changed
 
 - orchestra 0.1.7: `/create-workflow` is a Grok Build bundled skill at

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ has replaced that versioned directory.
 | Hook | Claude Code | Codex | Description |
 |------|-------------|-------|-------------|
 | `session-context` | SessionStart | SessionStart | Injects bounded branch, history, and plugin context |
+| `repo-freshness` | SessionStart | SessionStart | Non-destructively fast-forwards the active repo's branch/default ref to its remote when strictly behind; warns on divergence, never touches a dirty tree, never prompts |
 | `prompt-router` | UserPromptSubmit | — | Injects concise skill and agent routing hints with session deduplication |
 | `bouncer` | Bash PreToolUse | Shell PreToolUse | Validates commands against safety rules |
 | `damage-control` | Bash/write/edit PreToolUse | Shell/`apply_patch` PreToolUse | Protects sensitive paths and destructive operations |

--- a/hooks/claude-hooks.json
+++ b/hooks/claude-hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "BOPEN_HOOK_SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\"; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=$(ls -t \"$HOME/.claude/plugins/cache/b-open-io/core/\"*/hooks/session-context.sh 2>/dev/null | head -n 1); fi; if [ -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_RUNTIME=claude bash \"$BOPEN_HOOK_SCRIPT\"; fi",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "BOPEN_HOOK_SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/repo-freshness.sh\"; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=$(ls -t \"$HOME/.claude/plugins/cache/b-open-io/core/\"*/hooks/repo-freshness.sh 2>/dev/null | head -n 1); fi; if [ -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_RUNTIME=claude bash \"$BOPEN_HOOK_SCRIPT\"; fi",
+            "timeout": 12
           }
         ]
       }

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "BOPEN_HOOK_SCRIPT=\"${PLUGIN_ROOT}/hooks/session-context.sh\"; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=$(ls -t \"$HOME/.codex/plugins/cache/b-open-io/core/\"*/hooks/session-context.sh 2>/dev/null | head -n 1); fi; if [ -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_RUNTIME=codex bash \"$BOPEN_HOOK_SCRIPT\"; fi",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "BOPEN_HOOK_SCRIPT=\"${PLUGIN_ROOT}/hooks/repo-freshness.sh\"; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=$(ls -t \"$HOME/.codex/plugins/cache/b-open-io/core/\"*/hooks/repo-freshness.sh 2>/dev/null | head -n 1); fi; if [ -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_RUNTIME=codex bash \"$BOPEN_HOOK_SCRIPT\"; fi",
+            "timeout": 12
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "BOPEN_HOOK_SCRIPT=\"${GROK_PLUGIN_ROOT}/hooks/session-context.sh\"; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-context.sh\"; fi; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=$(ls -t \"$HOME/.grok/installed-plugins/\"*/hooks/session-context.sh 2>/dev/null | head -n 1); fi; if [ -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_RUNTIME=grok bash \"$BOPEN_HOOK_SCRIPT\"; fi",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "BOPEN_HOOK_SCRIPT=\"${GROK_PLUGIN_ROOT}/hooks/repo-freshness.sh\"; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/repo-freshness.sh\"; fi; if [ ! -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_SCRIPT=$(ls -t \"$HOME/.grok/installed-plugins/\"*/hooks/repo-freshness.sh 2>/dev/null | head -n 1); fi; if [ -f \"$BOPEN_HOOK_SCRIPT\" ]; then BOPEN_HOOK_RUNTIME=grok bash \"$BOPEN_HOOK_SCRIPT\"; fi",
+            "timeout": 12
           }
         ]
       }

--- a/hooks/manifest.json
+++ b/hooks/manifest.json
@@ -53,6 +53,16 @@
       "description": "Summarizes the working repository (branch, recent commits, files changed in the last commit) and the installed plugin inventory into the session's opening context so the agent starts oriented."
     },
     {
+      "name": "repo-freshness",
+      "path": "hooks/repo-freshness.sh",
+      "event": "SessionStart",
+      "matcher": "*",
+      "tier": "workflow",
+      "runtimes": ["claude", "codex", "grok"],
+      "summary": "Keeps the active repo's default branch in sync with origin.",
+      "description": "At session start, fetches origin (throttled per-repo) and non-destructively keeps the default branch fresh so local checkouts don't silently drift behind the remote — e.g. behind an autonomous loop that advances origin every cycle. Fast-forwards the default branch when it is checked out with a clean tree and strictly behind, advances the branch ref only when the default is not checked out, warns (never resets/rebases) when the branch has diverged, and reports without touching a dirty tree. Never blocks or prompts. Disable via {\"hooks\": {\"repo-freshness\": false}}."
+    },
+    {
       "name": "hammertime",
       "path": "hooks/hammertime.py",
       "event": "Stop",

--- a/hooks/repo-freshness.sh
+++ b/hooks/repo-freshness.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# repo-freshness.sh — SessionStart hook. Keeps the active repo in sync with its
+# remote so local checkouts don't silently drift behind (e.g. behind an
+# autonomous loop that advances origin every cycle while the human checkout sits
+# still and falls dozens of commits behind).
+#
+# STRICTLY NON-DESTRUCTIVE. It only ever fast-forwards, and only when provably
+# safe:
+#   • checked-out branch, clean tree, strictly behind its upstream → git merge --ff-only
+#   • the default branch (when NOT checked out) is behind origin     → advance its ref only
+#   • branch has diverged from upstream (local commits not on remote)→ WARN, never touch
+#   • dirty working tree                                             → report, never touch
+# It never resets, rebases, merges non-ff, stashes, or touches a dirty tree, and
+# never blocks or prompts. Fetches are throttled per-repo to keep session start
+# fast. Any missing tool / missing remote / error just skips silently.
+#
+# Disable via hooks-config.json: {"hooks": {"repo-freshness": false}}.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh" 2>/dev/null || true
+
+# No `set -euo pipefail`: partial failure must never block session start.
+
+if declare -f hook_enabled >/dev/null 2>&1; then
+  hook_enabled "repo-freshness" || exit 0
+fi
+
+command -v git >/dev/null 2>&1 || exit 0
+
+input=$(cat 2>/dev/null || echo "{}")
+if declare -f resolve_cwd >/dev/null 2>&1; then
+  cwd="$(resolve_cwd "$input" 2>/dev/null || echo "$PWD")"
+else
+  cwd="$PWD"
+fi
+
+g() { git -C "$git_root" "$@"; }
+
+git_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$git_root" ]] || exit 0
+
+# Only meaningful for repos that actually have an 'origin' remote.
+g remote get-url origin >/dev/null 2>&1 || exit 0
+
+# --- throttle fetches: at most one per repo per TTL, to keep session start fast
+TTL="${BOPEN_REPO_FRESHNESS_TTL:-600}"   # seconds
+state_dir="${BOPEN_REPO_FRESHNESS_STATE_DIR:-${HOME}/.claude/core/repo-freshness}"
+mkdir -p "$state_dir" 2>/dev/null
+key="$(printf '%s' "$git_root" | shasum 2>/dev/null | awk '{print $1}')"
+[[ -n "$key" ]] || key="$(printf '%s' "$git_root" | md5 2>/dev/null || echo default)"
+stamp="${state_dir}/${key}.stamp"
+
+now="$(date +%s 2>/dev/null || echo 0)"
+last=0
+[[ -f "$stamp" ]] && last="$(cat "$stamp" 2>/dev/null || echo 0)"
+[[ "$last" =~ ^[0-9]+$ ]] || last=0
+if (( now - last >= TTL )); then
+  # Bound the fetch so a slow/offline network never hangs session start.
+  TO=""
+  command -v timeout  >/dev/null 2>&1 && TO="timeout 8"
+  command -v gtimeout >/dev/null 2>&1 && TO="gtimeout 8"
+  if $TO git -C "$git_root" fetch origin --prune --quiet >/dev/null 2>&1; then
+    printf '%s' "$now" > "$stamp" 2>/dev/null
+  fi
+fi
+
+repo="$(basename "$git_root")"
+cur="$(g rev-parse --abbrev-ref HEAD 2>/dev/null || echo)"
+notes=()
+
+# ---- primary: sync the CHECKED-OUT branch to its own upstream --------------
+# Drive off @{u} (every tracked branch has one) rather than origin/HEAD, which
+# is frequently unset. This is exactly the drift case: sitting on a branch whose
+# remote has moved ahead.
+upstream="$(g rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+if [[ -n "$upstream" ]]; then
+  behind="$(g rev-list --count "HEAD..${upstream}" 2>/dev/null || echo 0)"
+  ahead="$(g rev-list --count "${upstream}..HEAD" 2>/dev/null || echo 0)"
+  [[ "$behind" =~ ^[0-9]+$ ]] || behind=0
+  [[ "$ahead"  =~ ^[0-9]+$ ]] || ahead=0
+  if (( behind > 0 && ahead == 0 )); then
+    if [[ -z "$(g status --porcelain 2>/dev/null)" ]]; then
+      if g merge --ff-only "$upstream" >/dev/null 2>&1; then
+        notes+=("Auto-fast-forwarded ${repo} ${cur} to ${upstream} (was ${behind} behind). Working tree was clean.")
+      fi
+    else
+      notes+=("${repo} ${cur} is ${behind} behind ${upstream} but the working tree is dirty — not auto-updating. Commit or stash, then: git pull --ff-only")
+    fi
+  elif (( behind > 0 && ahead > 0 )); then
+    notes+=("WARNING: ${repo} ${cur} has DIVERGED from ${upstream} (${behind} behind, ${ahead} ahead). Do NOT build on it until reconciled — inspect the local-only commits first: git log --oneline ${upstream}..HEAD")
+  fi
+fi
+
+# ---- secondary: keep the DEFAULT branch fresh while you work elsewhere ------
+# Best-effort default-branch resolution: origin/HEAD if set, else main/master.
+def="$(g symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's#^refs/remotes/origin/##')"
+if [[ -z "$def" ]]; then
+  for cand in main master; do
+    g rev-parse --verify --quiet "refs/remotes/origin/$cand" >/dev/null 2>&1 && { def="$cand"; break; }
+  done
+fi
+if [[ -n "$def" && "$cur" != "$def" ]] && g rev-parse --verify --quiet "refs/heads/$def" >/dev/null 2>&1; then
+  if g merge-base --is-ancestor "$def" "origin/$def" 2>/dev/null; then
+    dbehind="$(g rev-list --count "${def}..origin/${def}" 2>/dev/null || echo 0)"
+    [[ "$dbehind" =~ ^[0-9]+$ ]] || dbehind=0
+    if (( dbehind > 0 )); then
+      g update-ref "refs/heads/$def" "refs/remotes/origin/$def" 2>/dev/null \
+        && notes+=("Fast-forwarded ${repo} ${def} ref to origin (${dbehind} commits) while you work on ${cur}.")
+    fi
+  elif ! g merge-base --is-ancestor "origin/$def" "$def" 2>/dev/null; then
+    notes+=("WARNING: ${repo} local ${def} has diverged from origin/${def}. Reconcile it before branching off it.")
+  fi
+fi
+
+(( ${#notes[@]} > 0 )) || exit 0
+
+# Join notes with newlines under a single [REPO-FRESHNESS] banner.
+note="[REPO-FRESHNESS]"
+for n in "${notes[@]}"; do note="${note}
+- ${n}"; done
+
+# Emit SessionStart additionalContext (Claude format), matching session-context.sh.
+if command -v python3 >/dev/null 2>&1; then
+  ADDITIONAL="$note" python3 - <<'PY'
+import json, os
+ctx = os.environ.get("ADDITIONAL", "")
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ctx}}, ensure_ascii=False))
+PY
+else
+  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' \
+    "$(printf '%s' "$note" | sed 's/"/\\"/g' | awk 'BEGIN{ORS="\\n"}{print}')"
+fi

--- a/hooks/session-context.sh
+++ b/hooks/session-context.sh
@@ -392,10 +392,15 @@ if command -v python3 >/dev/null 2>&1 && [[ -f "$BUILDER_SCRIPT" ]]; then
   if [[ ! -f "$ROUTER_INDEX" ]]; then
     needs_rebuild=true
   elif [[ -d "$CACHE_ROOT" ]]; then
-    newest_cache_mtime=$(find "$CACHE_ROOT" -maxdepth 2 -type d -print0 2>/dev/null \
-      | xargs -0 stat -f '%m' 2>/dev/null \
-      || find "$CACHE_ROOT" -maxdepth 2 -type d -printf '%T@\n' 2>/dev/null)
-    newest_cache_mtime=$(printf '%s\n' "$newest_cache_mtime" | sort -rn | head -n1)
+    # Per-entry mtime with a BSD-then-GNU stat fallback (same portable pattern
+    # as index_mtime below). The previous `xargs stat -f '%m'` was BSD-only and
+    # did not cleanly fail on Linux, so the `-printf` fallback never ran and
+    # printf '%.0f' later choked on GNU stat's default multi-line output.
+    newest_cache_mtime=$(
+      find "$CACHE_ROOT" -maxdepth 2 -type d 2>/dev/null | while IFS= read -r _d; do
+        stat -f '%m' "$_d" 2>/dev/null || stat -c '%Y' "$_d" 2>/dev/null
+      done | sort -rn | head -n1
+    )
     index_mtime=$(stat -f '%m' "$ROUTER_INDEX" 2>/dev/null || stat -c '%Y' "$ROUTER_INDEX" 2>/dev/null || echo 0)
     if [[ -n "$newest_cache_mtime" ]] && (( $(printf '%.0f' "${newest_cache_mtime:-0}") > $(printf '%.0f' "${index_mtime:-0}") )); then
       needs_rebuild=true

--- a/hooks/session-context.sh
+++ b/hooks/session-context.sh
@@ -392,16 +392,19 @@ if command -v python3 >/dev/null 2>&1 && [[ -f "$BUILDER_SCRIPT" ]]; then
   if [[ ! -f "$ROUTER_INDEX" ]]; then
     needs_rebuild=true
   elif [[ -d "$CACHE_ROOT" ]]; then
-    # Per-entry mtime with a BSD-then-GNU stat fallback (same portable pattern
-    # as index_mtime below). The previous `xargs stat -f '%m'` was BSD-only and
-    # did not cleanly fail on Linux, so the `-printf` fallback never ran and
-    # printf '%.0f' later choked on GNU stat's default multi-line output.
+    # Portable epoch-mtime: GNU `stat -c %Y` first (Linux), BSD `stat -f %m`
+    # fallback (macOS). GNU-first matters — BSD-form `stat -f '%m'` on GNU parses
+    # `-f` as --file-system and `%m` as a bogus operand, printing the default
+    # `File: …` block to stdout instead of an mtime. A numeric-only filter guards
+    # against any such garbage before printf '%.0f' consumes it.
+    _sc_mtime() { stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null; }
     newest_cache_mtime=$(
       find "$CACHE_ROOT" -maxdepth 2 -type d 2>/dev/null | while IFS= read -r _d; do
-        stat -f '%m' "$_d" 2>/dev/null || stat -c '%Y' "$_d" 2>/dev/null
-      done | sort -rn | head -n1
+        _sc_mtime "$_d"
+      done | grep -E '^[0-9]+$' | sort -rn | head -n1
     )
-    index_mtime=$(stat -f '%m' "$ROUTER_INDEX" 2>/dev/null || stat -c '%Y' "$ROUTER_INDEX" 2>/dev/null || echo 0)
+    index_mtime=$(_sc_mtime "$ROUTER_INDEX" | grep -E '^[0-9]+$' | head -n1)
+    [[ -n "$index_mtime" ]] || index_mtime=0
     if [[ -n "$newest_cache_mtime" ]] && (( $(printf '%.0f' "${newest_cache_mtime:-0}") > $(printf '%.0f' "${index_mtime:-0}") )); then
       needs_rebuild=true
     fi

--- a/hooks/tests/run-tests.sh
+++ b/hooks/tests/run-tests.sh
@@ -98,6 +98,8 @@ source "$TESTS_DIR/test_pretooluse_bash.sh"
 # shellcheck disable=SC1091
 source "$TESTS_DIR/test_session_context.sh"
 # shellcheck disable=SC1091
+source "$TESTS_DIR/test_repo_freshness.sh"
+# shellcheck disable=SC1091
 source "$TESTS_DIR/test_hammertime.sh"
 # shellcheck disable=SC1091
 source "$TESTS_DIR/test_hook_enabled.sh"

--- a/hooks/tests/test_repo_freshness.sh
+++ b/hooks/tests/test_repo_freshness.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# repo-freshness: non-destructive default-branch sync at SessionStart.
+# Verifies: silent when non-git / up-to-date; auto-ff when clean+behind;
+# report-only when dirty; warn (no mutation) when diverged; ref-only advance
+# when on a feature branch. Uses local bare "origin" repos — no network.
+
+echo
+echo "--- repo-freshness ---"
+
+# Force a fetch every invocation and isolate throttle state to a temp dir.
+export BOPEN_REPO_FRESHNESS_TTL=0
+_RF_STATE=$(mktemp -d)
+export BOPEN_REPO_FRESHNESS_STATE_DIR="$_RF_STATE"
+
+_rf_git() { git -C "$1" -c user.email=t@t -c user.name=t "${@:2}"; }
+
+# Build: bare origin (default branch main) + a work clone + a mover clone.
+_rf_setup() {
+  local base; base=$(mktemp -d)
+  git -c init.defaultBranch=main init -q --bare "$base/origin.git"
+  git -c init.defaultBranch=main init -q "$base/work"
+  _rf_git "$base/work" commit -q --allow-empty -m c1
+  git -C "$base/work" remote add origin "$base/origin.git"
+  git -C "$base/work" push -q -u origin main
+  git clone -q "$base/origin.git" "$base/mover"
+  printf '%s' "$base"
+}
+# Advance origin/main by one empty commit via the mover clone.
+_rf_advance() {
+  git -C "$1/mover" checkout -q main
+  _rf_git "$1/mover" commit -q --allow-empty -m "$2"
+  git -C "$1/mover" push -q origin main
+}
+_rf_ctx() { printf '%s' "$1" | jq -r '.hookSpecificOutput.additionalContext // ""'; }
+
+# --- non-git directory -> silent, exit 0 ---
+NON_GIT=$(mktemp -d)
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$NON_GIT" '{cwd:$cwd}')"
+assert_exit "repo-freshness non-git exit" "0" "$HOOK_EXIT"
+assert_eq "repo-freshness non-git silent" "" "$HOOK_STDOUT"
+rm -rf "$NON_GIT"
+
+# --- up-to-date -> silent ---
+B=$(_rf_setup)
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$B/work" '{cwd:$cwd}')"
+assert_exit "repo-freshness uptodate exit" "0" "$HOOK_EXIT"
+assert_eq "repo-freshness uptodate silent" "" "$HOOK_STDOUT"
+
+# --- default checked out, clean, behind -> AUTO fast-forward ---
+_rf_advance "$B" c2
+_rf_advance "$B" c3
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$B/work" '{cwd:$cwd}')"
+assert_exit "repo-freshness ff exit" "0" "$HOOK_EXIT"
+assert_json "repo-freshness ff json" "$HOOK_STDOUT"
+assert_contains "repo-freshness ff message" "Auto-fast-forwarded" "$(_rf_ctx "$HOOK_STDOUT")"
+assert_eq "repo-freshness ff advanced HEAD" "0" "$(git -C "$B/work" rev-list --count HEAD..origin/main)"
+
+# --- dirty tree + behind -> REPORT only, no ff ---
+_rf_advance "$B" c4
+echo dirty > "$B/work/uncommitted.txt"
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$B/work" '{cwd:$cwd}')"
+assert_contains "repo-freshness dirty message" "working tree is dirty" "$(_rf_ctx "$HOOK_STDOUT")"
+assert_eq "repo-freshness dirty did not ff" "1" "$(git -C "$B/work" rev-list --count HEAD..origin/main)"
+rm -f "$B/work/uncommitted.txt"
+
+# --- diverged (local commit not on origin) -> WARN, no mutation ---
+_rf_git "$B/work" commit -q --allow-empty -m local-only
+before_head=$(git -C "$B/work" rev-parse HEAD)
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$B/work" '{cwd:$cwd}')"
+assert_contains "repo-freshness diverged warns" "DIVERGED" "$(_rf_ctx "$HOOK_STDOUT")"
+assert_eq "repo-freshness diverged untouched" "$before_head" "$(git -C "$B/work" rev-parse HEAD)"
+
+# --- on a feature branch, default behind -> ff the ref only, tree untouched ---
+C=$(_rf_setup)
+git -C "$C/work" checkout -q -b feature-x
+_rf_advance "$C" c2
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$C/work" '{cwd:$cwd}')"
+assert_contains "repo-freshness feature ff-ref message" "Fast-forwarded" "$(_rf_ctx "$HOOK_STDOUT")"
+assert_eq "repo-freshness feature stays on branch" "feature-x" "$(git -C "$C/work" rev-parse --abbrev-ref HEAD)"
+assert_eq "repo-freshness feature main advanced" \
+  "$(git -C "$C/work" rev-parse origin/main)" "$(git -C "$C/work" rev-parse main)"
+
+rm -rf "$B" "$C" "$_RF_STATE"
+unset BOPEN_REPO_FRESHNESS_TTL BOPEN_REPO_FRESHNESS_STATE_DIR


### PR DESCRIPTION
## Why
Local checkouts silently drift behind the remote because the autonomous loop advances `origin` every cycle while the human main checkout is never pulled forward. Concrete failure: `scribe-desktop` local `master` fell **91 commits behind** origin (and diverged on a stale version-bump commit) before it was noticed.

## What
New `repo-freshness` SessionStart hook (claude/codex/grok) that, at session start, non-destructively keeps the active repo in sync with its remote:

| Situation | Action |
|-----------|--------|
| checked-out branch, clean, strictly behind its upstream | `git merge --ff-only` |
| default branch behind origin (you're on another branch) | advance its ref only |
| branch diverged (local commits not on remote) | **WARN** — never reset/rebase |
| dirty working tree | report — never touch |

- Drives off the branch's own `@{u}` upstream (robust; not the frequently-unset `origin/HEAD`), with a `main`/`master` fallback for the default-branch convenience.
- Fetch is **throttled per-repo** (default 600s TTL) and **time-bounded** so session start stays fast; offline/slow simply skips.
- Never blocks, never prompts, never runs a destructive git op (won't trip the bouncer guard).
- Disable via `{"hooks": {"repo-freshness": false}}`.

## Wiring & tests
- Added to `claude-hooks.json`, `codex-hooks.json`, `hooks.json`, and `manifest.json` (runtime parity).
- 15 new tests in `test_repo_freshness.sh` covering non-git, up-to-date, auto-ff, dirty, diverged, and feature-branch cases. **379 total passing, 0 failing.**
- Smoke-tested against a real up-to-date repo → silent, no mutation.

Closes OPL-3602.