### PR TITLE
OPL-3605: software-factory — the verified multi-model pipeline recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ manifests share the same release version.
 
 ### Added
 
+- orchestra 0.1.8 / software-factory 0.0.7: "The staged multi-model pipeline —
+  the verified recipe" — the concrete wiring the maker/checker doctrine was
+  missing. Plan on the strongest model (premise verification before
+  decomposition, per-item lane + roster-agent routing), implement on cheap
+  workers (external CLI via the supervisor-agent pattern, or named roster
+  agents), adversarial review by an independent cross-vendor checker that
+  reviews the CLAIMS as well as the diff, gate + ship on a pinned main seat.
+  Every invocation shape was live-verified headless (native Workflow inside
+  `claude -p`, fable/grok-4.6/gpt-5.6-sol lanes) before being written down.
+  Includes the field case that forced it: a single-context loop wrote an
+  unverified "rotate the credential" diagnosis into a ticket and a second
+  single-context agent flipped it to "stale" — no adversarial reviewer existed
+  to demand evidence from either. Non-negotiables: pin every model (a loop
+  inheriting a mutable CLI default silently ran weeks on a stale model),
+  checker-or-propose-only, lane preflight with explicit degradation, and the
+  vendor data boundary.
+
 - `repo-freshness` SessionStart hook (claude/codex/grok): non-destructively
   keeps the active repo in sync with its remote so local checkouts don't
   silently drift behind — e.g. behind an autonomous loop that advances origin

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Multi-agent orchestration for Claude Code, Grok and Codex: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Multi-agent orchestration for Claude Code, Grok and Codex: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/skills/software-factory/SKILL.md
+++ b/modules/orchestra/skills/software-factory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: software-factory
-version: 0.0.6
+version: 0.0.7
 description: >-
   Design or harden a software factory: an agentic loop that iterates toward a goal with a
   verification gate, persistent state, and a stop condition. Use for "build a loop", "agentic
@@ -64,6 +64,48 @@ The dedup-vs-open-tickets step is what stops discovery from re-filing the same i
 At factory scale, a **router** sits above all worker types: work arrives typed (chore, bug, feature, hotfix), and the router picks the workflow and the model tier for it — a workhorse maker for volume, a state-of-the-art model only where planning or checking earns it. Speed-critical work (hotfixes) can **race**: several isolated agents attack the same fix in parallel and the first one through the gate wins. Isolation progresses with maturity — git worktrees are a great place to start and a poor place to end; sandboxes give full isolation plus a place a human can step into mid-run.
 
 **On Claude Code specifically**, staged fan-outs inside a loop pass — find → adversarially verify → synthesize, judge panels, loop-until-dry discovery — can run as a native `Workflow` (deterministic script, live `/workflows` progress, resumable). This is framework-dependent and opt-in-gated; see `skills/coordinator/references/native-workflows.md` for when it applies. On other runtimes, the manual wave protocols in `wave-coordinator` do the same job.
+
+## The staged multi-model pipeline — the verified recipe
+
+The maker/checker split above is doctrine; this is the concrete, field-verified wiring for an
+execution worker. **A headless loop that runs one monolithic session — one model playing planner,
+maker, checker, and shipper in a single context — will eventually write a wrong diagnosis into a
+ticket as fact, because its mechanical gate verifies code and nothing verifies claims.** (Field case:
+a loop asserted "rotate the credential" on a CI outage without evidence; a second single-context agent
+then flipped it to "stale, skip it" — also without evidence. Both survived because no adversarial
+reviewer ever existed. The outage was real; both written diagnoses were unverified guesses.)
+
+The verified shape — every lane below was live-tested headless before this section was written:
+
+| Stage | Model / lane | Invocation (verified) | What it guards |
+|---|---|---|---|
+| **Plan** | strongest planner (e.g. fable) | native `Workflow` `agent(..., { model: 'fable', schema })` | Premise verification BEFORE decomposition; routes each item to a lane + named roster agent |
+| **Implement** | cheap workers: external CLI (e.g. `grok -m grok-4.6 --permission-mode acceptEdits`) or named roster agents (`agentType`) | supervisor-agent pattern: a thin workflow agent writes the spec file, drives the CLI via Bash, relays the report + `git diff --stat` | Volume off the main seat; disjoint file partitions per item |
+| **Review** | independent CROSS-VENDOR checker (e.g. `codex exec -m gpt-5.6-sol --sandbox read-only`) | supervisor agent builds a review brief (diff + every claim), demands a schema verdict | The missing gate: adversarial review of the diff AND the claims; one corrective round max |
+| **Gate + ship** | main seat, model PINNED in loop config | mechanical gate unpiped, then git | Merge requires gate green **AND** `verdict.approved` |
+
+Non-negotiables learned the hard way:
+
+- **The native `Workflow` tool works inside headless `claude -p`** — verified. Commit the workflow
+  script to the repo (`scriptPath`), version it like code, and give it a `selftest` arg so CI and
+  humans can probe parse/load without spawning agents. (Runtime gotcha: the exported `meta` const is
+  not in scope in the script body; `Date.now()`/`Math.random()` are unavailable — pass timestamps in
+  via args.)
+- **Pin every model explicitly — the loop config, the workflow stages, the CLI dispatches.** A loop
+  that inherits a mutable CLI default silently runs on whatever model the maintainer's interactive
+  sessions last saved; a real loop ran weeks on a stale model this way and nobody knew.
+- **The checker reviews CLAIMS, not just diffs.** Any diagnosis, decline rationale, or "X is broken
+  because Y" that will be written to a ticket must carry evidence and pass the checker first.
+  Unverifiable ⇒ label it "unverified hypothesis" or write nothing. Claims-only tickets route through
+  the same review stage with no diff.
+- **No checker ⇒ propose-only.** Lane preflight (binary + auth + pinned-model-exists, e.g.
+  `grok models | grep`) runs every cycle; a down worker lane re-routes explicitly to roster agents,
+  and a down checker lane downgrades the cycle to open-PR-and-stop. The loop never self-approves, and
+  a lane never silently collapses into the main seat.
+- **Data boundary:** external lanes cross vendors (specs to xAI, review briefs to OpenAI). Specs and
+  briefs carry code excerpts, never secrets or env values. launchd does not source shell profiles —
+  file-based auth (codex `auth.json`, `grok login`) or an explicitly-sourced env file, checked at
+  preflight.
 
 ### Agent runtime selection
 


### PR DESCRIPTION
## Why
The skill prescribed maker/checker separation as doctrine (block 3, questionnaire field 6, the mega-skill failure-mode warning) — but had **no concrete recipe**, so a real deployment (the scribe loop) shipped as a single monolithic session anyway. Result: a wrong diagnosis was written into a Linear ticket as fact, and a second single-context agent flipped it to "stale" — neither claim ever faced an adversarial reviewer.

## What
New section **"The staged multi-model pipeline — the verified recipe"**:
- **Plan** — strongest model (fable): premise verification BEFORE decomposition; routes each item to a lane + named roster agent.
- **Implement** — cheap workers: external CLI (grok-4.6, `acceptEdits`) via the supervisor-agent pattern, or named roster `agentType`s.
- **Review** — independent cross-vendor checker (`codex exec -m gpt-5.6-sol`, read-only): adversarial review of the diff **and every claim**; schema verdict; one corrective round.
- **Gate + ship** — pinned main seat; merge requires gate green **AND** `verdict.approved`.

Non-negotiables encoded: pin every model (a live loop silently ran weeks on a stale CLI default), checker-or-propose-only, per-cycle lane preflight with explicit degradation, claims-review for diagnosis-only work, vendor data boundary, and the Workflow runtime gotchas (`meta` not in scope, no `Date.now`).

**Every invocation shape was live-verified headless before being written down** (native Workflow inside `claude -p`; fable / grok-4.6 / gpt-5.6-sol lanes; roster agentType resolution).

Versions: software-factory 0.0.6 → 0.0.7, orchestra module 0.1.7 → 0.1.8 (manifest pair verified in sync; docs gate green).

Companion implementation: b-open-io/scribe-desktop OPL-3604 (loop v2 exec pipeline).

Closes OPL-3605.