### PR TITLE
Fail loud when the benchmark judge reply cannot be parsed

### DIFF
--- a/scripts/benchmark.tsx
+++ b/scripts/benchmark.tsx
@@ -840,8 +840,9 @@ async function main() {
     }
 
     const avg = (arr: number[]) => arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
-    const wsPassRates = evalResults.filter(e => !e.with_skill.grade_error).map(e => e.with_skill.pass_rate);
-    const blPassRates = evalResults.filter(e => !e.baseline.grade_error).map(e => e.baseline.pass_rate);
+    const graded = evalResults.filter(e => !e.with_skill.grade_error && !e.baseline.grade_error);
+    const wsPassRates = graded.map(e => e.with_skill.pass_rate);
+    const blPassRates = graded.map(e => e.baseline.pass_rate);
 
     const generatedAt = new Date().toISOString();
     const runner = getRunner();

--- a/scripts/benchmark.tsx
+++ b/scripts/benchmark.tsx
@@ -61,25 +61,31 @@ interface AssertionResult {
   reasoning: string;
 }
 
+interface VariantRunResult {
+  output: string;
+  tokens: number;
+  duration_ms: number;
+  assertions: AssertionResult[];
+  pass_rate: number;
+  cached: boolean;
+  /** Present only when the judge reply could not be parsed. */
+  judge_raw?: string;
+  /** Present only when grading failed to parse; not a real assertion grade. */
+  grade_error?: string;
+}
+
+interface GradeOutcome {
+  assertions: AssertionResult[];
+  pass_rate: number;
+  judge_raw?: string;
+  grade_error?: string;
+}
+
 interface EvalRunResult {
   eval_id: number;
   prompt: string;
-  with_skill: {
-    output: string;
-    tokens: number;
-    duration_ms: number;
-    assertions: AssertionResult[];
-    pass_rate: number;
-    cached: boolean;
-  };
-  baseline: {
-    output: string;
-    tokens: number;
-    duration_ms: number;
-    assertions: AssertionResult[];
-    pass_rate: number;
-    cached: boolean;
-  };
+  with_skill: VariantRunResult;
+  baseline: VariantRunResult;
 }
 
 interface SkillBenchmark {
@@ -526,6 +532,54 @@ async function runClaude(
 // LLM-as-judge grading
 // ---------------------------------------------------------------------------
 
+export class GradeParseError extends Error {
+  readonly raw: string;
+  constructor(message: string, raw: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "GradeParseError";
+    this.raw = raw;
+  }
+}
+
+function looksLikeGrade(v: unknown): v is { id: string; passed?: boolean; reasoning?: string } {
+  return !!v && typeof v === "object" && typeof (v as { id?: unknown }).id === "string";
+}
+
+/** Parse a judge reply into assertion grades. Throws GradeParseError on miss. */
+export function parseJudgeGrades(raw: string, assertions: Assertion[]): AssertionResult[] {
+  const candidates: string[] = [];
+  const trimmed = raw.trim();
+  if (trimmed) candidates.push(trimmed);
+  const fence = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence?.[1]) candidates.push(fence[1].trim());
+  const greedy = raw.match(/\[[\s\S]*\]/);
+  if (greedy) candidates.push(greedy[0]);
+
+  let lastParseError: unknown;
+  for (const text of candidates) {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (!Array.isArray(parsed) || !parsed.some(looksLikeGrade)) continue;
+      return assertions.map(a => {
+        const grade = parsed.find(g => looksLikeGrade(g) && g.id === a.id);
+        return {
+          id: a.id,
+          text: a.text,
+          passed: grade?.passed ?? false,
+          reasoning: grade?.reasoning ?? "missing",
+        };
+      });
+    } catch (err) {
+      lastParseError = err;
+    }
+  }
+
+  const detail = lastParseError instanceof Error && /\[/.test(raw)
+    ? `grader JSON parse failed: ${lastParseError.message}`
+    : "no JSON array of {id, passed, reasoning} in grader response";
+  throw new GradeParseError(detail, raw, lastParseError instanceof Error ? { cause: lastParseError } : undefined);
+}
+
 async function gradeAssertions(
   output: string,
   expectedOutput: string,
@@ -549,21 +603,36 @@ JSON array:`;
 
   const result = await runClaude(gradingPrompt, { model });
   try {
-    const jsonMatch = result.output.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) throw new Error("no JSON array in grader response");
-    const parsed: { id: string; passed: boolean; reasoning: string }[] = JSON.parse(jsonMatch[0]);
-    return assertions.map(a => {
-      const grade = parsed.find(g => g.id === a.id);
-      return { id: a.id, text: a.text, passed: grade?.passed ?? false, reasoning: grade?.reasoning ?? "missing" };
-    });
-  } catch {
-    return assertions.map(a => ({ id: a.id, text: a.text, passed: false, reasoning: "grading parse error" }));
+    return parseJudgeGrades(result.output, assertions);
+  } catch (err) {
+    if (err instanceof GradeParseError) throw err;
+    throw new GradeParseError(
+      err instanceof Error ? err.message : String(err),
+      result.output,
+      err instanceof Error ? { cause: err } : undefined,
+    );
   }
 }
 
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
+
+function variantResult(
+  run: { output: string; tokens: number; duration_ms: number; cached: boolean } | undefined,
+  grade: GradeOutcome | undefined,
+): VariantRunResult {
+  return {
+    output: (run?.output ?? "").slice(0, 2000),
+    tokens: run?.tokens ?? 0,
+    duration_ms: run?.duration_ms ?? 0,
+    assertions: grade?.assertions ?? [],
+    pass_rate: grade?.pass_rate ?? 0,
+    cached: run?.cached ?? false,
+    ...(grade?.judge_raw ? { judge_raw: grade.judge_raw } : {}),
+    ...(grade?.grade_error ? { grade_error: grade.grade_error } : {}),
+  };
+}
 
 async function main() {
   const repoRoot = resolve(import.meta.dir, "..");
@@ -632,7 +701,8 @@ async function main() {
 
   // Result storage
   const runResults = new Map<string, { output: string; tokens: number; duration_ms: number; cached: boolean }>();
-  const gradeResults = new Map<string, { assertions: AssertionResult[]; pass_rate: number }>();
+  const gradeResults = new Map<string, GradeOutcome>();
+  const gradeFailures: { key: string; error: string; raw?: string }[] = [];
 
   // Shared mutable job queue (run jobs first, grade jobs pushed as runs complete)
   const jobQueue: Job[] = [...runJobs];
@@ -719,7 +789,16 @@ async function main() {
           dispatch({ type: "GRADE_DONE", skill: job.skill, evalId: job.evalId, variant: job.variant, passRate });
           triggerRerender();
         } catch (err) {
-          dispatch({ type: "ERROR", skill: job.skill, evalId: job.evalId, variant: job.variant, error: err instanceof Error ? err.message : String(err) });
+          const msg = err instanceof Error ? err.message : String(err);
+          const raw = err instanceof GradeParseError ? err.raw : undefined;
+          gradeResults.set(key, {
+            assertions: [],
+            pass_rate: 0,
+            grade_error: msg,
+            ...(raw !== undefined ? { judge_raw: raw } : {}),
+          });
+          gradeFailures.push({ key, error: msg, raw });
+          dispatch({ type: "ERROR", skill: job.skill, evalId: job.evalId, variant: job.variant, error: msg });
           triggerRerender();
         }
       }
@@ -755,28 +834,14 @@ async function main() {
       evalResults.push({
         eval_id: evalCase.id,
         prompt: evalCase.prompt,
-        with_skill: {
-          output: (wsRun?.output ?? "").slice(0, 2000),
-          tokens: wsRun?.tokens ?? 0,
-          duration_ms: wsRun?.duration_ms ?? 0,
-          assertions: wsGrade?.assertions ?? [],
-          pass_rate: wsGrade?.pass_rate ?? 0,
-          cached: wsRun?.cached ?? false,
-        },
-        baseline: {
-          output: (blRun?.output ?? "").slice(0, 2000),
-          tokens: blRun?.tokens ?? 0,
-          duration_ms: blRun?.duration_ms ?? 0,
-          assertions: blGrade?.assertions ?? [],
-          pass_rate: blGrade?.pass_rate ?? 0,
-          cached: blRun?.cached ?? false,
-        },
+        with_skill: variantResult(wsRun, wsGrade),
+        baseline: variantResult(blRun, blGrade),
       });
     }
 
     const avg = (arr: number[]) => arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
-    const wsPassRates = evalResults.map(e => e.with_skill.pass_rate);
-    const blPassRates = evalResults.map(e => e.baseline.pass_rate);
+    const wsPassRates = evalResults.filter(e => !e.with_skill.grade_error).map(e => e.with_skill.pass_rate);
+    const blPassRates = evalResults.filter(e => !e.baseline.grade_error).map(e => e.baseline.pass_rate);
 
     const generatedAt = new Date().toISOString();
     const runner = getRunner();
@@ -858,13 +923,29 @@ async function main() {
   await new Promise(r => setTimeout(r, 600));
   unmount();
 
+  if (gradeFailures.length > 0) {
+    console.error(`\nBenchmark failed: ${gradeFailures.length} unparseable judge ${gradeFailures.length === 1 ? "reply" : "replies"}`);
+    for (const f of gradeFailures) {
+      console.error(`  ${f.key}: ${f.error}`);
+      if (f.raw) {
+        console.error(`  --- raw judge reply ---`);
+        console.error(f.raw);
+        console.error(`  --- end raw judge reply ---`);
+      }
+    }
+    console.error(`Diagnostics written to ${outPath}`);
+    process.exit(1);
+  }
+
   console.log(`\nBenchmark Complete`);
   console.log(`  Skills: ${report.total_skills}  Evals: ${report.total_evals}`);
   console.log(`  With skill: ${(report.overall_pass_rate * 100).toFixed(1)}%  Baseline: ${(report.overall_baseline_pass_rate * 100).toFixed(1)}%`);
   console.log(`  Report: ${outPath}`);
 }
 
-main().catch(err => {
-  console.error("Benchmark failed:", err);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch(err => {
+    console.error("Benchmark failed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`gradeAssertions` in `scripts/benchmark.tsx` asked the judge for a JSON array of `{id, passed, reasoning}`, regex-extracted `/\[[\s\S]*\]/`, and on any parse miss stamped every assertion `passed: false` with reasoning `"grading parse error"`. The raw judge reply was discarded.

That is exactly the committed repro in `benchmarks/latest.json`: skill `auth-md`, eval 1, model `claude-haiku-4-5-20251001`. The with-skill output starts `**Safety Verdict—STOP. This mapping is unsafe.**` and refuses password collection / `/sign-up/email`, but all four assertions failed with reasoning exactly `"grading parse error"`. Baseline eval 1 was a real 0%; the with-skill 0% was a dead grade that still fed the published headline.

## Change

- Parse misses throw `GradeParseError` (includes the raw judge text). No silent fallback that writes fake assertion failures.
- The worker records `judge_raw` + `grade_error` on the variant, writes them to `benchmarks/latest.json` (and the per-skill file), prints the raw reply, and **exits 1**.
- Well-formed JSON-array grades (plain, fenced, or greedy-extracted) still map to assertions as before.
- If either variant of an eval has `grade_error`, that eval is dropped from **both** `pass_rate` and `baseline_pass_rate`. A published delta always compares the same set.

No version bump, no marketplace / bopen-ai changes.

## Verify

- Direct `parseJudgeGrades` cases: well-formed array, fenced JSON, greedy extract, and unparseable prose all behave as above (throw preserves `.raw`).
- `bash hooks/tests/run-tests.sh` — 379 passed, 0 failed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1947e47-b0b2-4db3-8b09-d62f9fe0d40f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1947e47-b0b2-4db3-8b09-d62f9fe0d40f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

