### PR TITLE
Add Grok Bot roster stand-up (not Grok Build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ manifests share the same release version.
 
 ### Added
 
-- Grok Bot roster stand-up: [docs/grok-bot.md](docs/grok-bot.md). Grok Bot is
-  the teammate app, not Grok Build (`grok plugin install`). README Installation
-  now has a Grok Bot subsection next to Codex. There is no marketplace install
-  command; pasting the stand-up prompt is the install path.
+- Grok Bot roster stand-up: long form in [docs/grok-bot.md](docs/grok-bot.md)
+  (will be served at https://bopen.ai/install/grok-bot.md once the site PR
+  lands). README Installation has a Grok Bot subsection next to Codex with
+  the tiny paste-first prompt. Not Grok Build (`grok plugin install`). No
+  marketplace install command.
 
 ## [1.1.140] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Added
+
+- Grok Bot roster stand-up: [docs/grok-bot.md](docs/grok-bot.md). Grok Bot is
+  the teammate app, not Grok Build (`grok plugin install`). README Installation
+  now has a Grok Bot subsection next to Codex. There is no marketplace install
+  command; pasting the stand-up prompt is the install path.
+
 ## [1.1.140] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -117,7 +117,13 @@ filenames retain the readable `bopen-*.toml` convention.
 
 Grok Bot is the teammate app. It is not Grok Build (the `grok` CLI / `grok plugin install` path above).
 
-Stand up the bOpen roster by pasting [docs/grok-bot.md](docs/grok-bot.md) into an operator Grok Bot that can create teammates. That bot fetches `agents/front-desk.md` with `gh api` and creates one teammate per display name. It does not clone this repo.
+Paste this first into an operator Grok Bot that can create teammates:
+
+```text
+Fetch https://bopen.ai/install/grok-bot.md and follow it exactly. Stand up the bOpen.ai roster as Grok Bot teammates. This is not Grok Build — do not run grok plugin install.
+```
+
+The long form that URL will serve is [docs/grok-bot.md](docs/grok-bot.md) (https://bopen.ai/install/grok-bot.md once the site PR lands). That bot fetches `agents/front-desk.md` with `gh api` and creates one teammate per display name. It does not clone this repo.
 
 There is no marketplace install command for Grok Bot. Creating teammates from the roster file is the install path.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ discovered. Installed runtime agent names use the `bopen_` prefix and
 underscores, such as `bopen_agent_builder` and `bopen_code_auditor`. Generated
 filenames retain the readable `bopen-*.toml` convention.
 
+### Grok Bot
+
+Grok Bot is the teammate app. It is not Grok Build (the `grok` CLI / `grok plugin install` path above).
+
+Stand up the bOpen roster by pasting [docs/grok-bot.md](docs/grok-bot.md) into an operator Grok Bot that can create teammates. That bot fetches `agents/front-desk.md` with `gh api` and creates one teammate per display name. It does not clone this repo.
+
+There is no marketplace install command for Grok Bot. Creating teammates from the roster file is the install path.
+
 ### Updating
 
 Use each host's marketplace update path; do not copy files into a plugin cache

--- a/docs/grok-bot.md
+++ b/docs/grok-bot.md
@@ -1,0 +1,59 @@
+# Stand up the bOpen roster in Grok Bot
+
+This is for **Grok Bot teammates**. It is not Grok Build (`grok plugin install`).
+
+Paste the block below to an operator Grok Bot that can create teammates.
+
+---
+
+You are standing up the [bOpen.ai](https://bopen.ai) specialist roster as Grok Bot teammates.
+
+## Source of truth
+
+- Roster: `b-open-io/prompts` `agents/front-desk.md` (Team Directory tables)
+- Company: `b-open-io/prompts` `COMPANY.md`
+- Each persona is a markdown file in that repo, or in a plugin repo named in the table
+
+Fetch with `gh api`. Do not `git clone`.
+
+## Create
+
+For every row in that directory:
+
+1. Fetch the agent markdown
+2. Create a teammate whose **name is the display_name** (Martha, Kayle, Zack, …)
+3. Description = title + when-to-use + personality + do-not-do + skills you will actually use from that file
+4. Append the org rules below
+
+Also create the Other Plugins seats named in that file: David, Uno Satoj, Anthony, Siggy, Johnny, Ordi, Caal.
+
+## Skip
+
+- **agent-builder / Satchmo** — that is the human
+- **documentation-writer / Flow** — the name collides with other products
+- **ceo** — skip if an operator already exists. Otherwise create **Tina** (executive-assistant) as operator
+
+## Org rules (append to every description)
+
+- One named operator (default Tina) unless the human is speaking directly
+- Use your computer. Named folders stay. Loose junk goes to `/workspace/scratch`. Secrets never live in `/workspace`
+- Run `skills/humanize` from `b-open-io/prompts` on anything a person reads
+- Sleep 22:00–08:00 America/New_York unless they lift it
+- Optional DEFCON: each agent remembers its own base timings and multiplies them (5 Cruise ×1, 4 ×0.5, 3 ×0.25, 2 ×0.125, 1 ×0.05 or a 15-minute floor). Never overwrite the base.
+- Friday: self-assess against the source persona and update instructions
+- Do not invent capabilities or numbers
+
+## After they exist
+
+Message each teammate:
+
+> Read your source file. Write into memory only the skills and tools you will actually use. If another seat should steal a skill, say who and which.
+
+Relay those steals. Do not dump the whole catalog into one agent.
+
+## Do not
+
+- Create two teammates with the same display name
+- Clone the prompts repo onto the machine
+- Treat app-specific bots as core roster members
+- Confuse this with Grok Build plugin install (`grok plugin install …`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two hosts stay split. This PR does not mix them.

## Grok Build (unchanged)

Existing plugin CLI path. Not this PR.

- README shared install blocks stay as they already were: `grok plugin install core@b-open-io --trust` / `grok plugin install orchestra@b-open-io --trust`
- Zack's trusted setup-emitter command stays `grok plugin install b-open-io/prompts --trust` (`skills/setup/scripts/emitter.ts` + tests + playground). Not rewritten to `core@b-open-io`.
- No Grok Bot text was folded into those lines.

## Grok Bot (this PR only)

Teammate app. No CLI. Not Grok Build.

- `docs/grok-bot.md` — long-form stand-up, verbatim. This is what a bot fetches. Not the tiny prompt.
- README `### Grok Bot` after Codex, before `### Updating`. Paste-first tiny prompt:

  `Fetch https://bopen.ai/install/grok-bot.md and follow it exactly. Stand up the bOpen.ai roster as Grok Bot teammates. This is not Grok Build — do not run grok plugin install.`

  Long form is `docs/grok-bot.md` and will be served at https://bopen.ai/install/grok-bot.md once the site PR lands.
- CHANGELOG Unreleased only. No version bump. `marketplace.json` and `skills/setup/scripts/runtimes.ts` untouched. No runtime id — Grok Bot is not a plugin CLI.

## Site host cards

Confirmed: the bopen.ai plugin page cards (Claude Code / Codex / Grok Build) are **not generated from this repo**.

This repo has no `src/lib/plugin-installs.ts` and no catalog `PluginInstallSection.tsx`. The only `PluginInstallSection` here is Agent Master's local playground UI (`skills/setup/playground/src/components/setup/PluginTab.tsx`), which is Claude/Codex install-plan checkboxes, not the public site cards.

Those cards live in **`b-open-io/bopen-ai`**. Stop. Add any Grok Bot card there, not here.

Linear: OPL-3713.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6492afeb-b93b-4d77-9ca1-844b8af903cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6492afeb-b93b-4d77-9ca1-844b8af903cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

