### PR TITLE
OPL-3616: repo-freshness reports a parked, fully-merged branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Fixed
+
+- `repo-freshness` kept the checked-out branch and the default branch's ref in
+  sync but never noticed you were parked on a **finished** branch — one whose
+  commits are all already in the default branch. Every freshness glance
+  reported clean-and-current because technically it was, while new work would
+  branch off stale history. A real checkout sat on a months-merged feature
+  branch through an entire release cycle and was caught only in the release
+  preflight. The hook now reports it (report-only; switching branches stays the
+  maintainer's call) and names the exact command to fix it.
+
 ### Changed
 
 - `front-desk` 1.1.12 / skill 1.0.6: Martha knows Grok Bot ≠ Grok Build.

--- a/hooks/repo-freshness.sh
+++ b/hooks/repo-freshness.sh
@@ -113,6 +113,26 @@ if [[ -n "$def" && "$cur" != "$def" ]] && g rev-parse --verify --quiet "refs/hea
   fi
 fi
 
+# ---- parked on a DEAD branch --------------------------------------------
+# The gap this closes: the checks above keep whatever you have checked out in
+# sync, and keep the default branch's ref fresh — but neither notices that the
+# branch you are sitting on is FINISHED. A feature branch whose commits are all
+# already in the default branch is dead: new work started from it silently
+# branches off stale history, and every "is the repo ready" glance reports
+# clean-and-current because, technically, it is. Observed cost: a checkout sat
+# on a months-merged feature branch through an entire release cycle, noticed
+# only in the release preflight (2026-08-21).
+# Report only — switching branches is the maintainer's call, never a hook's.
+if [[ -n "$def" && -n "$cur" && "$cur" != "$def" && "$cur" != "HEAD" ]]; then
+  if g merge-base --is-ancestor HEAD "origin/$def" 2>/dev/null; then
+    if [[ -z "$(g status --porcelain 2>/dev/null)" ]]; then
+      notes+=("${repo} is parked on '${cur}', which is FULLY MERGED into ${def} — that branch is finished, so work started here would build on stale history. Switch before starting anything new: git -C '${git_root}' checkout ${def} && git pull --ff-only")
+    else
+      notes+=("${repo} is parked on '${cur}', which is fully merged into ${def} (finished branch), and the working tree is dirty. Commit or stash, then switch to ${def}.")
+    fi
+  fi
+fi
+
 (( ${#notes[@]} > 0 )) || exit 0
 
 # Join notes with newlines under a single [REPO-FRESHNESS] banner.

--- a/hooks/tests/test_repo_freshness.sh
+++ b/hooks/tests/test_repo_freshness.sh
@@ -80,5 +80,18 @@ assert_eq "repo-freshness feature stays on branch" "feature-x" "$(git -C "$C/wor
 assert_eq "repo-freshness feature main advanced" \
   "$(git -C "$C/work" rev-parse origin/main)" "$(git -C "$C/work" rev-parse main)"
 
+
+# --- parked on a FULLY MERGED (dead) branch -> report, never switch ---
+D=$(_rf_setup)
+git -C "$D/work" checkout -q -b finished-feature
+_rf_git "$D/work" commit -q --allow-empty -m "feature work"
+git -C "$D/work" push -q origin finished-feature:main   # its work lands in the default branch
+git -C "$D/work" fetch -q origin
+before_branch=$(git -C "$D/work" rev-parse --abbrev-ref HEAD)
+run_hook "repo-freshness.sh" "claude" "$(jq -n --arg cwd "$D/work" '{cwd:$cwd}')"
+assert_contains "repo-freshness dead-branch reported" "FULLY MERGED" "$(_rf_ctx "$HOOK_STDOUT")"
+assert_eq "repo-freshness dead-branch does NOT switch" "$before_branch" "$(git -C "$D/work" rev-parse --abbrev-ref HEAD)"
+rm -rf "$D"
+
 rm -rf "$B" "$C" "$_RF_STATE"
 unset BOPEN_REPO_FRESHNESS_TTL BOPEN_REPO_FRESHNESS_STATE_DIR


### PR DESCRIPTION
**The gap:** `repo-freshness` fast-forwards the checked-out branch and advances the default branch's ref — but never notices the branch you're *on* is finished (all its commits already in the default branch). Every freshness glance reports clean-and-current, because technically it is, while any new work branches off stale history.

**Observed cost:** a real checkout sat on a months-merged feature branch through an entire release cycle and was caught only during the release preflight.

**Fix:** detect the parked-on-merged case and report it with the exact command to fix. Report-only — switching branches stays the maintainer's decision, never a hook's. Dirty trees get the commit-or-stash variant instead.

Two regression tests added (dead branch is reported; hook does NOT switch). Suite: **381 passing, 0 failing.**