### PR TITLE
coordinator(0.0.11): graph-tax framing + the arbitrage discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Changed
+
+- `coordinator` (0.0.11): added a "graph tax" framing to Delegation Economics.
+  Names the real coordination overhead of LLM orchestration (Anthropic's ~4×
+  agent / ~15× multi-agent token multipliers; LangChain's supervisor-translation
+  cost) and makes explicit the discriminator that justifies dispatch anyway —
+  a genuine price gap between a cheap executor and the premium main seat. Guards
+  against paying the tax with no offset: same-tier orchestration and trivial
+  units stay in the main seat.
+
 ### Fixed
 
 - `repo-freshness` kept the checked-out branch and the default branch's ref in

--- a/modules/orchestra/skills/coordinator/SKILL.md
+++ b/modules/orchestra/skills/coordinator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coordinator
-version: 0.0.10
+version: 0.0.11
 description: >-
   Route bounded code-writing volume from a capable Claude Code, Codex, or Grok
   Build main session to cheaper or specialized executors — native plugin-roster
@@ -232,6 +232,33 @@ conflicts — the whole-project typecheck was green the moment the last
 worker landed.
 
 ## Delegation Economics
+
+**The graph tax is real — arbitrage is what offsets it.** Orchestration is not
+free control logic. Every dispatch spends tokens on *management*, not the task:
+the main seat re-establishes context, the worker re-reads a spec, results get
+reviewed and reconciled. An edge in a fan-out diagram looks like a costless
+line; economically it is a communication event — serialize state, move context,
+pay the executor to reprocess it, integrate the result. The measured overhead is
+large: agent runs use ~4× the tokens of a plain chat and multi-agent designs
+~15× (Anthropic, 2025); a supervisor that "translates" worker output can cost
+more tokens *and* lose accuracy versus a flatter design (LangChain, 2025). When
+the manager and the workers are the *same expensive model*, that tax buys
+nothing — five nodes where one loop would ship is pure loss dressed as rigor.
+
+**What makes this pattern pay is the price gap, not the graph.** Coordinator
+dispatch is justified only when the executor is materially cheaper, or genuinely
+more specialized, than the main seat: bounded code volume routed to a cheap
+worker (a Grok subagent, GPT-5.6 Sol, a lower-tier native agent) while premium
+judgment — plan, interfaces, review, git — stays on the expensive seat. With a
+real price gap, even a 5–15× token multiplier on the *cheap* side is a net win,
+because the alternative was spending *premium* tokens typing the same code.
+Remove the price gap and every critique of "agent graphs" applies to you in
+full. So the discriminator for each unit is concrete: **is this executor cheaper
+(or better at this exact unit) than doing it here — by enough to clear the
+dispatch floor?** If yes, dispatch. If the worker is the same tier as the main
+seat, or the unit is a one-liner, the tax has nothing to offset it: do it here.
+Fan out for volume and price arbitrage, never for the appearance of
+sophistication.
 
 - **Every dispatch has a fixed floor cost** — spec writing, context
   re-establishment, review. Splitting finer does not monotonically get


### PR DESCRIPTION
Incorporates the insight from Craig Wright's *The Graph Tax — AI Agent Graphs Are an Inefficient Way to Work* into the `coordinator` skill's Delegation Economics.

**The critique:** LLM agent graphs spend tokens on coordination/management, not the task — Anthropic reports ~4× tokens for agents and ~15× for multi-agent vs chat; LangChain found a supervisor that 'translates' worker output costs more tokens *and* loses accuracy. His argument assumes the manager and workers are the **same expensive model**, so the coordination is pure loss.

**What the skill adds:** the discriminator that argument omits — **model arbitrage**. Coordinator dispatch pays *because* the executor (Grok subagent, Sol, lower-tier agent) is materially cheaper than the premium main seat. With a real price gap, even a 5–15× token multiplier on the *cheap* side beats spending *premium* tokens typing the same code. Remove the price gap (same-tier orchestration) or apply it to a one-liner, and the tax has nothing to offset it → stay in the main seat.

Skill version 0.0.10 → 0.0.11; CHANGELOG updated; `check-docs.py` passes.