### PR TITLE
feat(humanize): sales-copy reference from attributed sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Changed
+
+- `humanize` 1.0.12 adds an attributed-source rule and a dedicated revision
+  pass for outbound email, discovery questions, call openers, and sales
+  scripts. It grounds each draft in a supplied account fact, removes canned
+  sales tells, and does not invent commercial claims.
+
 ## [1.1.148] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ intentional.
 | `cli-demo-gif` | Generate CLI demo GIFs using vhs (Charmbracelet) |
 | `generative-ui` | Guardrailed JSON Render interfaces with flat specs, small catalogs, deterministic directives, and text fallbacks |
 | `html-to-pdf` | Design print-ready collateral and render it through a Playwright PDF pipeline |
-| `humanize` | Preserve facts and house style while removing clustered AI-writing patterns, unsupported significance, vague attribution, promotional drift, and canned change summaries |
+| `humanize` | Preserve facts and house style while removing clustered AI-writing patterns, unsupported significance, vague attribution, promotional drift, canned change summaries, and template-like sales copy; outbound drafts use attributed examples and supplied account facts without inventing commercial claims |
 | `persona` | Capture writing style profiles and social intelligence |
 | `ui-audio-theme` | Audit and wire existing products, then generate, visually edit, reassign, and audition cohesive app, game HUD, and TV navigation sound themes — via ElevenLabs samples or a synthesized cuelume web micro-interaction path, guided by a production-agnostic interaction taxonomy |
 | `visual-proposal` | Present an unbuilt design, RFC, roadmap, or options space as a grounded, diagram-led HTML proposal. For real decisions it runs a default panel of named roster-agent advocates (with avatars) → cross-examination → a judging bench → the CEO's holistic final call, humanizes every voice, and ends with selectable option cards + a copy-response button that pastes a version-stamped reply back to the agent. Pages save to `docs/proposals/` and include a side menu of other proposals: local rows copy agent instructions; PostPlan rows are real links |

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: humanize
-version: 1.0.11
+version: 1.0.12
 description: >-
   This skill should be used for human-facing prose — emails, docs, reports, posts, release notes,
   and commit messages — when the user asks to "humanize", "make this sound less AI", "de-AI
-  this", "this sounds like ChatGPT", or "edit this". Preserve facts, evidence, citations, house
-  style, and intended meaning while removing clustered AI-writing patterns.
+  this", "this sounds like ChatGPT", or "edit this". This skill should also be used when the user
+  asks to "humanize this sales email", "this SDR copy sounds like AI", "cold email",
+  "outbound email", or "sales script". Preserve facts, evidence, citations, house style, and
+  intended meaning while removing clustered AI-writing patterns.
 user-invocable: false
 ---
 
@@ -169,6 +171,17 @@ Read [references/style-modeling.md](references/style-modeling.md) before using a
 named writer on long-form work. Skip this step for short copy, reference docs,
 changelogs, and established house voices.
 
+## Sales copy
+
+When the draft is outbound email, a first reply, a discovery question, a call
+opener, or a sales script, also read
+[references/sales.md](references/sales.md).
+
+Use a line as few-shot only when a named person sent or received it and a
+result is attached. Do not use SaaS template mills. Ground one un-fakeable
+fact from this account. If research is thin, say less. Do not invent warmth,
+reach, or prices.
+
 ## Mandatory revision pass
 
 Run this pass silently before delivering human-facing prose. When the user asks
@@ -196,6 +209,10 @@ annotations, or an edit summary.
    disclaimers. Preserve explicit house style.
 10. For operational summaries, replace process assurances with the concrete
     change.
+11. For sales copy, also run the checks in
+    [references/sales.md](references/sales.md): attributed sources only, one
+    un-fakeable fact, banned sales tells, observation then implication then
+    one question.
 
 ## Stop condition
 
@@ -215,3 +232,6 @@ possible indicator disappears; that produces another synthetic house style.
   before/after transformations
 - **[references/style-modeling.md](references/style-modeling.md)** — Structural
   modeling for long-form work
+- **[references/sales.md](references/sales.md)** — Outbound and sales-script
+  checks: source rule, sales tells, attributed examples, voice card. Search
+  `Source rule`, `Sales-specific tells`, `Attributed examples`, `Voice card`.

--- a/skills/humanize/evals/evals.json
+++ b/skills/humanize/evals/evals.json
@@ -117,6 +117,39 @@
           "type": "qualitative"
         }
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Humanize this outbound sales email. Preserve every supplied fact and do not add prices, reach numbers, named jobs, customers, or capabilities. Return only the rewritten email.\n\nSupplied facts: ConstructionMagazine.ai is a trade magazine about AI that ran on a named construction job. Ads and partner messages are labeled. Write advertising@constructionmagazine.ai. Acme Equipment posted a hiring note last week for a robotics field tech.\n\n\"I hope this email finds you well. I'm reaching out because we help construction-tech leaders leverage cutting-edge media to streamline pipeline. Saw Acme's growth — that kind of growth usually means brand is lagging awareness. We offer a robust, comprehensive sponsorship. Worth a quick 15 minutes? No pitch attached, happy to share if useful, no worries if not. Let me know if you have any questions.\"",
+      "expected_output": "A short outbound note that keeps the labeled-ad magazine, the advertising mailbox, and Acme's robotics-field-tech hiring note; uses observation then implication then one question; and drops template-mill and AI-sales tells.",
+      "files": ["references/sales.md"],
+      "assertions": [
+        {
+          "id": "hum-5-preserves-supplied-facts",
+          "text": "The output keeps ConstructionMagazine.ai as a magazine about AI that ran on a named construction job, labeled ads or partner messages, advertising@constructionmagazine.ai, and Acme Equipment's hiring note for a robotics field tech.",
+          "type": "qualitative"
+        },
+        {
+          "id": "hum-5-no-invented-commercial-claims",
+          "text": "The output adds no price, subscriber or reach number, named job, customer result, or product capability beyond the supplied facts.",
+          "type": "qualitative"
+        },
+        {
+          "id": "hum-5-kills-sales-tells",
+          "text": "The output does not retain or paraphrase these tells: 'I hope this email finds you well', 'I'm reaching out', 'leverage', 'cutting-edge', 'streamline', 'that kind of growth usually means', 'robust', 'comprehensive', 'worth a quick 15 minutes', 'no pitch attached', 'happy to share if useful', 'let me know if you have any questions'.",
+          "type": "qualitative"
+        },
+        {
+          "id": "hum-5-observation-implication-question",
+          "text": "The output leads with the Acme hiring fact (or a direct restatement), draws one implication that stays inside the supplied facts, and ends on one question rather than a meeting-length CTA.",
+          "type": "qualitative"
+        },
+        {
+          "id": "hum-5-copy-only",
+          "text": "The output contains only the rewritten email, with no change log, editorial rationale, annotations, or explanation of the revision.",
+          "type": "qualitative"
+        }
+      ]
     }
   ]
 }

--- a/skills/humanize/references/sales.md
+++ b/skills/humanize/references/sales.md
@@ -1,0 +1,274 @@
+# Sales copy
+
+Load this file when the draft is outbound email, a first reply, a discovery
+question, a call opener, or a sales script. The core humanize checks still
+apply. This file adds source rules, sales-specific tells, and a send shape
+that most general prose passes miss.
+
+Public sales benches measure process. They do not prove the copy sounds like a
+person. Score both. Language quality shows up first in reply rate against a
+human control.
+
+## Source rule
+
+Use a line as few-shot or as a pattern only when a named person sent or
+received it, and a result is attached (reply, meeting, or published as mail
+they answered). If the sender and the result cannot be named, do not use the
+line.
+
+Own closed-won and dead threads beat any public example. Feed 20–50 of the
+best-performing human emails and call snippets when they exist. A model copies
+distribution: "good AI drafts" produce polished sludge.
+
+Do not use SaaS SEO blogs or swipe files as examples:
+
+- Prospeo, Sendspark, GetReplies, Instantly template mills
+- Pages titled like "10 templates that get replies in 2026"
+- Any line of the form "Saw [trigger]. That usually means [generic pain]. We
+  help [role] [outcome]. Worth 15 minutes?"
+
+Trusted public sources when a private corpus is missing: Josh Braun
+(joshbraun.com and his LinkedIn), Steli Efti / Close Elastic script, Jon
+Buchan original letter, founder-to-founder notes posted with the actual send
+(Pinker-style, Wiza internal note). Quote them as written. Do not clean them
+up into brochure cadence.
+
+## Two scores
+
+Skip the public bench names when rewriting one email. They are calibration
+for a private eval.
+
+Score **outcome** and **language** on every sales draft.
+
+Outcome (did it sell or qualify): research mapped to this offer, a
+personalized first touch, discovery that raises intent, a next step or a
+clean disqualify, and a brief a human will accept. Public calibration:
+Microsoft Sales Qualification Bench, SalesLLM (deal progression, not nice
+dialogue), CRMArena-Pro, Salesforce CRM LLM bench. General agent benches
+(τ²-bench, AgentBench) are weak proxies for selling.
+
+Language (does it sound like a seller): answers the actual question, does not
+dump a monologue, does not restart the script every turn, one real fact about
+this account, peer tone not vendor tone, mixed sentence length, empathy that
+tracks the last message, discovery versus pitch ratio, one sharp question
+instead of three generic ones. Outbound email reading level around grade 8.
+
+Do not promote a prompt or model unless both a meeting-intent score and a
+"would I send this" rate beat the current baseline. Blind A/B: if sellers or
+prospects pick the human sample 70%+ of the time, the agent still sounds like
+a model.
+
+## Shape of a human send
+
+One concrete observation, one implication, one low-friction question. Prove
+homework in one sentence, then ask one question. Prefer to disqualify rather
+than oversell.
+
+> Generic AI: "I hope this email finds you well. I'm reaching out because we
+> help VP Sales leaders leverage cutting-edge tools to streamline pipeline."
+>
+> Human: "Saw Acme's eng team grew 40% last quarter. I cannot see from outside
+> whether coverage on the new product line kept up. Is that already handled,
+> or still a gap?"
+
+Use the Acme line only when those figures are in the brief. The move is the
+lesson, not the numbers. Do not replace the implication with "that kind of
+growth usually means [generic pain]." That is the mill template without a
+calendar ask.
+
+Human copy usually has at least one of: a detail that only fits this person,
+uneven rhythm, a question that creates a blank rather than a calendar ask, a
+voice that could be picked out of a lineup. Sometimes it is too long or too
+weird on purpose.
+
+Cadence for outbound email: lead with a short acknowledgment or the fact, one
+or two substance sentences, end on a question. Max about three sentences.
+Voice turns in discovery: 15–30 words. Use contractions. Skip perfect grammar
+when stiffness would be the tell.
+
+Ground every message in retrieval. The email must contain one un-fakeable
+detail (news, hiring, a quote from their blog, a named asset). If research is
+thin, say less. Do not invent warmth.
+
+Rewrite pass after the first draft: "Rewrite this as if a sharp human SDR sent
+it from their phone. Cut 30%. Keep the one specific fact."
+
+## Sales-specific tells
+
+Run the core lists in [words.md](words.md), [phrases.md](phrases.md), and
+[structures.md](structures.md). Then kill these sales forms those files do
+not own:
+
+Openers: "I hope this finds you well," "I'm reaching out to."
+
+Template sludge: "Worth a quick 15 minutes," "No pitch attached," "no
+strings," "That kind of growth usually means…"
+
+Softener stack: "happy to share if useful, no worries if not."
+
+Zero contractions in a short outbound note.
+
+Give or show something before the meeting ask. A question that creates a blank
+beats a calendar link in the first note.
+
+## Attributed examples
+
+Quote as written. Steal the move. Do not clone the gimmick.
+
+### Josh Braun, mail he answered and mail he sends
+
+A seller wrote him about a specific video. He published it because it made him
+reply:
+
+> Josh – Your video on sales anxiety was spot on. Enjoyed your two cents on
+> detaching from the outcome. Simple but not easy-:).
+>
+> Have you considered repurposing your videos for TikTok to expand reach
+> beyond LinkedIn?
+>
+> @abhormozi grew from 0-23k followers in two months without lifting a finger.
+>
+> Here's a demo to show you what it might look like.
+>
+> Is this something you’d be open to exploring?
+
+Move: names a specific video. "Have you considered" instead of "you should."
+Proof is a named person, not "companies like yours." The ask is interest, not
+a calendar.
+
+His own poke-the-bear openers:
+
+> If you run MVRs in January, how do you know there aren’t at-risk drivers in
+> March?
+>
+> How do you know SDRs that interview well will perform well?
+>
+> You must be some sort of spreadsheet magician if you’re using Excel and
+> Google Sheets to calculate and run commission statements.
+
+Those questions do not pitch. His 4-T email, in his words:
+
+> James, noticed your SDRs target HR/Benefit Directors in companies > 500
+> employees.
+>
+> Have you tried reverse engineering high-performing cold emails to boost
+> response rates?
+>
+> 4k+ reps are seeing an uptick. It involves a guide with copywriting +
+> underlying psychology of cold emails with proof of positive responses you
+> can steal.
+>
+> Here’s a peek.
+
+A different seller saw he had plantar fasciitis and mailed a home remedy with
+no demo ask. Give first, then the meeting is easy.
+
+### Jared Zelman to Steven Pinker (Pinker took the meeting)
+
+> Steven —
+>
+> I’m Jared Zelman, a senior at USC. I built a SaaS company to 30 employees in
+> high school, sold it in college, and spent last summer flipping burgers at
+> my local diner in NY.
+>
+> I recently watched your discussion with Joe Rogan and it really stuck with
+> me. Specifically, the way you explained progress from who you are to who you
+> want to be changed how I see the world as a senior in college. I’ve been
+> diving into your work since and learning a ton.
+>
+> I’d love your advice on a few personal and career questions about building
+> something meaningful in an environment (college) that often rewards
+> task-completion over creativity.
+>
+> I know it’s a long shot, but if you have a few minutes to chat, I’d be
+> really grateful and will make the most of it.
+
+Follow-up:
+
+> Steven — while I might be a new fan, I’ve spent probably 15 hours this week
+> (time which should have perhaps been spent studying for midterms) reading
+> Better Angels and Blank Slate.
+
+The parenthetical is human. Models almost never write "time which should have
+perhaps been spent studying." Specific and a little awkward beats smooth.
+
+### Wiza internal note (Hans, then forwarded)
+
+560 sends, 123 replies. The useful part is the 37-word note to a colleague,
+not the later product-y forward:
+
+> Hey Stephen,
+>
+> Came across {company} and thought they would be a good fit for us.
+>
+> Try reaching out to {Full Name}, seems to be the right contact.
+>
+> Looks like their team is using Sales Navigator. Cheers, H
+
+No CTA, no "leverage," no three-act structure. Use this cadence for a human
+handoff brief.
+
+### Jon Buchan "drunk email"
+
+He sent the letter; it booked Red Bull, Pepsi, HP, Symantec, and others. Do
+not clone the ferret, the top hat, or the profanity bait. The lesson is
+pattern interrupt plus a person on the page. One reply: "My colleague
+forwarded me your spam email and we would like to meet you."
+
+### Steli Efti / Close Elastic Sales
+
+Named, dated, tied to first customers. Opener:
+
+> Hi, my name is Steli Efti. I’m calling some startups in the area to find out
+> if they are a good fit for our beta program.
+>
+> What we do in a sentence is we provide companies with a sales team on
+> demand.
+>
+> Does this sound generally interesting to you?
+
+Whatever they said (yes / maybe / no):
+
+> Interesting. Tell me about your sales process.
+
+When they asked for an email:
+
+> I certainly will, but so I know exactly what to include in that email, can
+> you tell me…
+
+Plain. Local. One-sentence pitch. Permission question. He does not
+"acknowledge and explore." He keeps going.
+
+### Mia Pugh → Rob Charlebois at LastPass
+
+She scrambled a headline into password-style leetspeak because LastPass sells
+passwords. He posted that he almost never replies to BDR mail and took the
+meeting. The joke was the relevance. Do not invent the body. If a genuine
+product hook exists in the brief, use it; otherwise skip the gag.
+
+## Voice card
+
+Skip this section for a single email rewrite. Use it when building a sales
+agent or a script set.
+
+Define a one-page voice before generating. Three adjectives. Two tones to
+refuse. Formality. Cadence. Fifteen phrases the best reps actually use.
+Fifteen phrases never allowed. One belief that repeats ("we don't book
+meetings that waste an AE's calendar").
+
+Persona, not "you are a helpful assistant": a senior AE in the vertical, peer
+not vendor, never opens with a compliment, proves homework in one sentence,
+asks one question, would rather disqualify than oversell.
+
+Split nodes rather than one god prompt: research brief, first touch, reply
+handling, discovery, objection, meeting ask, CRM writeback. Each node has its
+own length budget. Model discovery as six jobs gathered across turns, not a
+checklist dump: problem, pain size, cost of inaction, current workaround,
+stakeholders, timing.
+
+Generation: temperature about 0.4–0.6 for outreach, frequency and presence
+penalty so stock CTAs do not repeat, a hard max token so it cannot monologue.
+
+Keep human: pricing, multi-threaded politics, live-call emotion, final
+contract, brand strategy, anything that can blow a deal. Never auto-send a
+reply to a complaint. Never send a follow-up without the prior thread.


### PR DESCRIPTION
## Why

Sales drafts still sound like template mills because humanize had no sales-specific source rule.

## What

- `humanize` 1.0.12 loads `references/sales.md` for outbound email, SDR copy, cold email, and sales scripts.
- Few-shot only when a named person sent or received the line and a result is attached.
- Ban Prospeo/Sendspark-style templates. Shape is one observation, one implication, one question.
- Eval 5 covers a closed-world ConstructionMagazine.ai first-touch rewrite.

## Not in this PR

Changelog for the next core release still lives in the dirty working tree with other 1.1.149 notes.