### PR TITLE
Stop skipping Satchmo in Grok Bot stand-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Changed
+
+- Grok Bot stand-up no longer skips Satchmo; agent-builder is a real seat.
+
 ## [1.1.150] - 2026-08-26
 
 ### Changed

--- a/agents/front-desk.md
+++ b/agents/front-desk.md
@@ -56,7 +56,7 @@ Fetch https://bopen.ai/install/grok-bot.md and follow it exactly. Stand up the b
 
 Long form: https://bopen.ai/install/grok-bot.md (`docs/grok-bot.md` in `b-open-io/prompts`). Fetch with `gh api`. Do not `git clone`.
 
-Grok Bot creates one teammate per display name (Martha, Kayle, Zack, …). Skip Satchmo (the human) and Flow (name collision). Skip ceo if an operator already exists; otherwise create Tina as operator.
+Grok Bot creates one teammate per display name (Martha, Kayle, Zack, …). Skip Flow (name collision). Skip ceo if an operator already exists; otherwise create Tina as operator.
 
 ## Team Directory
 

--- a/codex/agents/bopen-front-desk.toml
+++ b/codex/agents/bopen-front-desk.toml
@@ -67,7 +67,7 @@ Fetch https://bopen.ai/install/grok-bot.md and follow it exactly. Stand up the b
 
 Long form: https://bopen.ai/install/grok-bot.md (`docs/grok-bot.md` in `b-open-io/prompts`). Fetch with `gh api`. Do not `git clone`.
 
-Grok Bot creates one teammate per display name (Martha, Kayle, Zack, …). Skip Satchmo (the human) and Flow (name collision). Skip ceo if an operator already exists; otherwise create Tina as operator.
+Grok Bot creates one teammate per display name (Martha, Kayle, Zack, …). Skip Flow (name collision). Skip ceo if an operator already exists; otherwise create Tina as operator.
 
 ## Team Directory
 

--- a/docs/grok-bot.md
+++ b/docs/grok-bot.md
@@ -29,7 +29,6 @@ Also create the Other Plugins seats named in that file: David, Uno Satoj, Anthon
 
 ## Skip
 
-- **agent-builder / Satchmo** — that is the human
 - **documentation-writer / Flow** — the name collides with other products
 - **ceo** — skip if an operator already exists. Otherwise create **Tina** (executive-assistant) as operator
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Grok Bot stand-up treated agent-builder as a skip. That seat is real. This removes only that skip from the public template.

Skip list now keeps Flow (name collision) and the existing ceo/operator rule.

No version bump. No extra seating policy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ecce306-3117-4fe8-9f18-cca45ccfacf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ecce306-3117-4fe8-9f18-cca45ccfacf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

