### PR TITLE
Harden factory bootstrap policy [OPL-2855]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.1.153",
+  "version": "1.1.154",
   "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code, Codex, and Grok Build",
   "author": {
     "name": "b-open-io",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.1.153",
+  "version": "1.1.154",
   "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code, Codex, and Grok Build",
   "author": {
     "name": "b-open-io",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ manifests share the same release version.
 
 ## Unreleased
 
+## [1.1.154] - 2026-08-31
+
+### Changed
+
+- `software-factory` 0.0.9 and `/factory-init` now treat factory bootstrap and
+  policy changes as High-tier, require feature-branch PR delivery, verify live
+  default-branch protection and the unattended worker identity, and keep loops
+  paused when state, model pins, checkers, or executable breakers are missing.
+  The Looptop contract now includes sanitized `events.jsonl` run/stage/worker/
+  gate telemetry, runtime worktrees, machine-readable factory policy, and
+  distinct exec/maintenance wrapper names for clear macOS background items.
+
 ## [1.1.153] - 2026-08-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ root-level files keep their filename as the command.
 - `/prime` - Context warm-up — loads git state, plugin inventory, and project conventions
 - `/question` - Read-only Q&A mode — answers questions about the codebase without making changes
 - `/diagnose` - Fan out 3-5 agents to investigate a bug from every angle simultaneously
-- `/factory-init` - Design and scaffold an autonomous agent loop with explicit goals, gates, state, stop conditions, and human-readable GitHub PRs
+- `/factory-init` - Design and scaffold an autonomous agent loop with explicit goals, gates, state, stop conditions, factory-aware Looptop telemetry, repository-policy preflight, and human-readable GitHub PRs
 - `/impact` - Map the full blast radius before changing a file or function
 - `/review-wave` - 4 specialized reviewers examine changes simultaneously (security, perf, correctness, style)
 - `/hammertime` - HammerTime behavioral rules — status dashboard (no args) or create a rule from a description

--- a/commands/factory-init.md
+++ b/commands/factory-init.md
@@ -60,6 +60,12 @@ Classify the loop's actions (Low / Medium / High). Write the **never-touch list*
 for anything irreversible. This boundary governs free-roam permission, the
 automation/promotion gate, and cleanup — all at once.
 
+Treat factory bootstrap and policy changes themselves as High-tier. If this is
+a Git repository, resolve the live default branch, create or reuse a non-default
+feature branch before writing factory files, and deliver the scaffold through a
+human-review PR. Never make the bootstrap commit directly on the default
+branch. Read `software-factory/references/repository-policy.md`.
+
 ### Step 5: Scaffold
 
 Produce a written loop config (store it in the chosen state backend or a
@@ -69,6 +75,15 @@ Produce a written loop config (store it in the chosen state backend or a
 - **State** — initialize the backend (Linear labels, GitHub `loop` labels, or `loop/state.md`).
 - **Maker/checker** — note the model split (cheap maker, strict checker).
 - **Stop conditions** — cap (15–20 to start), retries (2–3), pre-flight budget breaker.
+- **Repository policy** — for GitHub-backed delivery, run
+  `software-factory/scripts/check-factory-policy.sh` against the live default
+  branch and record the unattended worker identity. Protection plus a
+  non-bypass worker credential is required before scheduling; otherwise leave
+  the loop paused and manual. Do not create or change a repository rule without
+  explaining it and getting authorization at the time of that mutation.
+- **Executable safety** — missing/malformed state fails closed; pin every model;
+  enforce the configured iteration, retry, wall-clock, budget, and accept-rate
+  breakers in code rather than merely writing them into config.
 - **Human artifacts** — if field 9 includes `gh pr create`, follow
   `software-factory/references/human-artifacts.md`. Resolve this skill's
   directory and copy:
@@ -80,6 +95,12 @@ Produce a written loop config (store it in the chosen state backend or a
   exec/ship prompt: run `bash scripts/lint-pr.sh --title "$TITLE" --body-file "$BODY"`
   before `gh pr create`; put loop process in a PR **comment**, never the body.
   Do not scaffold this when the loop never opens a GitHub pull request.
+- **Observability** — register the worker with Looptop immediately in a paused,
+  manual-only posture. Include `runtimeDirs`, `telemetry.eventsPath`, and the
+  machine-readable `factory` policy in `loop.json`. Append sanitized
+  `run/stage/worker/gate/artifact/decision/policy` events to `events.jsonl`.
+  When separate exec and maintenance LaunchAgents exist, use distinct wrapper
+  executable names so macOS does not display indistinguishable background rows.
 
 ### Step 6: Prove, don't automate
 
@@ -88,3 +109,9 @@ Run the full cycle **once, watched**, on a real case. Confirm the gate actually
 after the loop is proven and hardened should the heartbeat (cron / `/loop` /
 `/goal` / GitHub Actions) be wired — and High blast-radius actions stay
 human-gated regardless. Hand that automation step to the `devops` agent.
+
+Before declaring the scaffold complete, verify all of the following and attach
+the evidence to the handoff: bootstrap PR URL; live branch-policy and worker
+identity check; valid paused state plus a missing-state rejection; model pins;
+breaker tests; PR-linter self-test; required status names; Looptop discovery;
+and at least one sanitized `events.jsonl` prove event.

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Multi-agent orchestration for Claude Code, Grok and Codex: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Multi-agent orchestration for Claude Code, Grok and Codex: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/skills/software-factory/README.md
+++ b/modules/orchestra/skills/software-factory/README.md
@@ -46,6 +46,11 @@ Build one only when all four hold. Miss a single box and a good one-shot prompt 
 
 The reversibility of what a loop can do — not its accept rate — sets how much freedom it gets. A loop that's right 99% of the time still deletes the production table on the run where it's wrong. Reversible actions (reads, drafts, sandbox writes) can self-certify once the gate is green; irreversible ones (prod deploys, deletes, payments, pushing to main) stay human-approved every time regardless of track record. This same classifier governs what free roam may touch and whether a verification step needs cleanup.
 
+That boundary includes the factory itself. Bootstrap and changes to runners,
+gates, CI, repository rules, or credentials go through a feature-branch PR;
+the factory may propose but cannot approve its own constitution. Verify the
+live default-branch rule and unattended worker identity before scheduling.
+
 ## Build order
 
 Prove it once by hand on a real case, watching the gate actually reject bad work. Harden it with stop conditions, a pre-flight budget breaker, and a state file. Only then wire the heartbeat and let it run unattended, because scheduling something you haven't proven reliable is how loops blow up while you sleep.

--- a/modules/orchestra/skills/software-factory/SKILL.md
+++ b/modules/orchestra/skills/software-factory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: software-factory
-version: 0.0.8
+version: 0.0.9
 description: >-
   Design or harden a software factory: an agentic loop that iterates toward a goal with a
   verification gate, persistent state, and a stop condition. Use for "build a loop", "agentic
@@ -180,6 +180,18 @@ The order matters more than the tools. Scheduling something you haven't made rel
 2. **Harden it** — add the stop conditions, circuit breaker, state file, never-touch list; run it watched a few more times; measure accept rate.
 3. **Automate it** — only now wire the heartbeat (cron/`/loop`/Actions). Promotion respects the blast-radius tier above.
 
+### The factory cannot exempt its own bootstrap
+
+Creating or changing the runner, gates, prompts, CI, repository rules, or
+credentials is a High-tier factory-policy change. Bootstrap on a feature
+branch and deliver it through a human-review PR; the factory may propose but
+never approve its own constitution. A prompt saying "propose-only" is not a
+security boundary. Before readiness, verify the live default-branch rule and
+the unattended worker's identity/capability with
+`references/repository-policy.md` and `scripts/check-factory-policy.sh`.
+Missing protection, missing/malformed state, mutable model defaults, or
+documentation-only breakers keep the factory paused and manual.
+
 ## Stop conditions — never optional
 
 Every loop needs at least one of each, or it runs until it succeeds, breaks, or drains the account:
@@ -237,4 +249,5 @@ registration, never no registration.
 - `references/failure-modes.md` — the catalog of quiet failure modes and their guards.
 - `references/human-artifacts.md` — GitHub PRs as human artifacts: AGENTS.md contract, lint-pr.sh, CI.
 - `references/looptop-registration.md` — the worker registration contract, verified against looptop source.
+- `references/repository-policy.md` — self-bootstrap, default-branch enforcement, and delivery identity checks.
 - `references/state-backends.md` — Linear vs GitHub Issues vs repo-vault, with the state-file contract.

--- a/modules/orchestra/skills/software-factory/references/config-questionnaire.md
+++ b/modules/orchestra/skills/software-factory/references/config-questionnaire.md
@@ -69,6 +69,11 @@ State must be readable by a **cold-start agent** — each iteration gets a fresh
 
 - What does the loop *act* on, not just describe? Open a PR, link/comment a ticket, ping a channel, deploy a preview.
 - Each connector that performs an irreversible action inherits the High blast-radius gate.
+- For GitHub delivery, resolve the live default branch and the exact credential
+  the unattended worker will use. Can that identity bypass branch rules or
+  approve its own PR? Run `scripts/check-factory-policy.sh`; documentation is
+  not evidence of enforcement. Keep the factory paused when protection or a
+  constrained worker identity is missing.
 - **If the loop opens GitHub PRs:** GitHub is for humans. Auto-merge without a
   human rewrite requires a mechanical PR linter, not another prompt. Follow
   `human-artifacts.md` and have `/factory-init` copy `lint-pr.sh`, the PR

--- a/modules/orchestra/skills/software-factory/references/failure-modes.md
+++ b/modules/orchestra/skills/software-factory/references/failure-modes.md
@@ -64,6 +64,18 @@ Malicious content in tool output poisons the agent's context and propagates acro
 Verification mutates real state (bogus rows, test users, orphaned files/webhooks); over many iterations the loop poisons its own environment.
 **Guard:** prefer ephemeral environments so there's nothing to clean; otherwise register teardown for every mutation, or explicitly accept the leftover for that project. See `config-questionnaire.md` field 4.
 
+## 12. Factory escapes its own boundary
+
+The runner is propose-only, but the setup session commits the runner or its
+policy directly to the default branch. The factory is safe only after it
+starts, while its constitution remains writable by the same unconstrained
+identity.
+**Guard:** treat bootstrap and factory-policy changes as High-tier. Create them
+on a feature branch through a human-review PR, enforce the default branch at
+the forge, and give the worker a distinct non-bypass identity. Verify the live
+rule with `repository-policy.md`; never trust a prompt or local hook as the
+authorization boundary.
+
 ## Pre-ship checklist
 
 Before automating, confirm a guard exists for each mode above, plus:
@@ -75,6 +87,7 @@ Before automating, confirm a guard exists for each mode above, plus:
 - [ ] Never-touch list defined and loaded each pass
 - [ ] Blast-radius tier assigned; High-tier actions human-gated
 - [ ] If the loop opens PRs: `lint-pr.sh` is wired and has been observed to reject a bad title
+- [ ] Bootstrap/policy changes use PRs; live default-branch protection and worker identity were verified
 
 ## The mega-skill
 

--- a/modules/orchestra/skills/software-factory/references/looptop-registration.md
+++ b/modules/orchestra/skills/software-factory/references/looptop-registration.md
@@ -13,6 +13,11 @@ looptop scans `~/Library/LaunchAgents/ai.<slug>.loop.exec.plist` (plus
 optional `ai.<slug>.loop.maintenance.plist`). No plist → the loop does not
 exist to looptop, even for manual `looptop run` kickstarts.
 
+When exec and maintenance use separate jobs, give their wrapper executables
+distinct names (`LoopTop-Name-Exec`, `LoopTop-Name-Maintenance`). macOS lists
+background items by executable name; pointing both jobs at one wrapper creates
+two indistinguishable rows even though they are different schedules.
+
 ## State dir: `~/.<slug>/loop/`
 
 (Resolved from `~/.<slug>/loop/loop.json` first, else the dirname of the
@@ -20,14 +25,20 @@ plist's `StandardOutPath`.) Four files:
 
 - `loop.json` — the manifest:
   `{ schemaVersion: 1, slug, displayName, labelPrefix: "ai.<slug>.loop",
-  stateDir, repoDir, modes: ["exec"], maintenance: [],
-  schedule: { exec: [], maintenance: [] }, host, createdAt }`
+  stateDir, repoDir, runtimeDirs: [repoDir], modes: ["exec"], maintenance: [],
+  schedule: { exec: [], maintenance: [] }, host, createdAt,
+  telemetry: { eventsPath: "<stateDir>/events.jsonl", agentTrail: true },
+  factory: { stages, model, checker, delivery, defaultBranch,
+  defaultBranchProtected } }`
   Empty `schedule.exec` = manual-only (prove phase).
 - `state.json` — mutable: `{ paused: true, exec_total: 0, exec_accepted: 0 }`.
   `looptop pause/resume <slug>` edits `paused`; the runner MUST honor it.
 - `ledger.jsonl` — one line per pass:
   `{ "ts", "mode": "exec"|"maintenance", "rc", "payload": { "result", "ref", "detail" } }`
 - `loop.log` — runner output; also the plist's `StandardOutPath`/`StandardErrorPath`.
+- `events.jsonl` — sanitized append-only run/stage/worker/gate/artifact/decision/
+  policy events. One `runId` per pass; never include credentials, environment
+  values, full prompts, or sensitive tool input.
 
 ## Plist (prove-phase shape)
 
@@ -41,9 +52,11 @@ from it when `~/.<slug>/loop/loop.json` is absent. Promotion to unattended
 
 ## Runner obligations
 
-One pass per invocation; check `state.json` `paused` FIRST and exit 0 with a
+One pass per invocation; missing or malformed `state.json` fails closed. Check
+`paused` FIRST and exit 0 with a
 `"skipped"` ledger entry when paused; append a ledger line for every outcome
-(completed / error / skipped) with the real `rc`; log to `loop.log`.
+(completed / error / skipped) with the real `rc`; append matching factory
+events; log to `loop.log`.
 
 Installing the plist + `launchctl load` is user-machine persistence — get the
 user's explicit go-ahead; never install it silently.

--- a/modules/orchestra/skills/software-factory/references/repository-policy.md
+++ b/modules/orchestra/skills/software-factory/references/repository-policy.md
@@ -1,0 +1,57 @@
+# Repository policy and factory self-bootstrap
+
+A factory's delivery boundary is not real until the repository enforces it.
+"Propose-only" in a prompt protects only the code path that read the prompt;
+it does not constrain the setup session, another tool, or an administrator
+credential.
+
+## Factory constitution
+
+Treat the files that define the factory itself as High-tier policy:
+
+- runner, prompts, model and budget configuration
+- verification gates and CI workflows
+- repository rules, CODEOWNERS, and credentials
+- loop manifest, state migration, and scheduling
+
+Create and change these files on a feature branch through a human-review PR.
+The factory may propose changes to its own constitution but cannot approve or
+merge them. Bootstrap is part of the factory boundary, not an exception to it.
+
+## Load-bearing controls
+
+Before declaring a GitHub-backed factory ready:
+
+1. Query the live default branch and confirm it is protected. Run
+   `scripts/check-factory-policy.sh`; do not infer protection from docs.
+2. Identify the credential the unattended worker will use. It must be a bot or
+   GitHub App that can push feature branches and open PRs but cannot bypass the
+   default-branch rule or approve its own work.
+3. Require pull requests for the default branch. For unattended factories,
+   use a ruleset with no worker/admin bypass, block force-push and deletion,
+   and require the actual gate status names used by the repository.
+4. CODEOWN the factory constitution so a distinct human identity reviews
+   changes to it.
+
+Local hooks are defense-in-depth. The hosting provider's rule is the
+authorization boundary.
+
+If protection or a constrained worker identity is missing, keep the worker
+paused and manual/prove-only. Missing or malformed state, an unpinned model,
+missing checker for auto-merge, or documentation-only budgets also fail
+readiness.
+
+## Acceptance evidence
+
+Factory initialization is complete only when the handoff records:
+
+- the bootstrap PR URL (never a direct default-branch commit)
+- live branch-policy check output and worker identity/capability
+- a valid paused `state.json` that the runner fails closed without
+- explicit model pins for every lane
+- executable iteration, retry, wall-clock, budget, and accept-rate breakers
+- PR linter self-test and the repository's real required status names
+- LoopTop registration plus a sanitized `events.jsonl` prove event
+
+Do not install or change repository rules silently. Explain the proposed rule
+and get authorization immediately before that external mutation.

--- a/modules/orchestra/skills/software-factory/scripts/check-factory-policy.sh
+++ b/modules/orchestra/skills/software-factory/scripts/check-factory-policy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-factory-policy.sh [--repo OWNER/REPO] [--branch NAME] [--require-non-admin]
+       check-factory-policy.sh --self-test
+
+Verifies the live GitHub default branch is protected. With
+--require-non-admin, also rejects ADMIN/MAINTAIN worker credentials.
+EOF
+}
+
+privileged_permission() {
+  case "$1" in
+    ADMIN|MAINTAIN) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+self_test() {
+  privileged_permission ADMIN
+  privileged_permission MAINTAIN
+  ! privileged_permission WRITE
+  ! privileged_permission READ
+  echo "check-factory-policy: self-test passed"
+}
+
+repo=""
+branch=""
+require_non_admin=0
+
+while (($#)); do
+  case "$1" in
+    --repo) repo="${2:?--repo requires OWNER/REPO}"; shift 2 ;;
+    --branch) branch="${2:?--branch requires NAME}"; shift 2 ;;
+    --require-non-admin) require_non_admin=1; shift ;;
+    --self-test) self_test; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "check-factory-policy: gh is required" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "check-factory-policy: gh is not authenticated" >&2; exit 1; }
+
+view="$(gh repo view ${repo:+"$repo"} --json nameWithOwner,defaultBranchRef,viewerPermission)"
+repo="${repo:-$(python3 -c 'import json,sys; print(json.load(sys.stdin)["nameWithOwner"])' <<<"$view")}"
+branch="${branch:-$(python3 -c 'import json,sys; print(json.load(sys.stdin)["defaultBranchRef"]["name"])' <<<"$view")}"
+permission="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["viewerPermission"])' <<<"$view")"
+protected="$(gh api "repos/$repo/branches/$branch" --jq '.protected')"
+
+if [[ "$protected" != "true" ]]; then
+  echo "check-factory-policy: FAIL $repo/$branch is not protected" >&2
+  exit 1
+fi
+if ((require_non_admin)) && privileged_permission "$permission"; then
+  echo "check-factory-policy: FAIL worker identity has bypass-capable permission $permission" >&2
+  exit 1
+fi
+
+printf 'check-factory-policy: PASS repo=%s branch=%s protected=true permission=%s\n' "$repo" "$branch" "$permission"


### PR DESCRIPTION
## Problem

Factory bootstrap could escape the propose-only boundary because repository protection, delivery identity, and runtime safety controls were documented but not verified.

## Change

Make factory bootstrap obey the same PR-only boundary as factory output. Add live branch-policy and worker-identity preflight, fail-closed readiness criteria, and the native Looptop event contract.

## Risk

Repository rules remain an explicit, separately authorized external change.
