### PR TITLE
Add OpenCode as a supported orchestra harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Added
+
+- OpenCode is a supported orchestra harness. `coordinator` 0.0.13 dispatches
+  `opencode run --model <provider/model>` workers (no `opencode exec` exists),
+  `orchestrator` 0.0.7 adds an OpenCode main adapter, and `advisor` 0.0.5 adds
+  an `opencode run` consult channel (including Muse Spark 1.3 via a custom
+  provider block). `detect-harness.sh` detects `OPENCODE=1` / `OPENCODE_PID`,
+  reports the `opencode` lane plus `opencode models` output and the configured
+  default, and caps OpenCode mains as flat dispatch (no native workflow).
+  `native-workflows.md` and `harness-capabilities.md` document the OpenCode
+  dispatch shape, and `wave-coordinator` 1.0.7 adds an OpenCode host adapter.
+  Skills are drop-in `SKILL.md` on OpenCode; hooks have no file
+  equivalent there (plugin event handlers). orchestra 0.1.17.
+
 ### Changed
 
 - `coordinator` 0.0.12 / `orchestrator` 0.0.6: worker volume is a named menu.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # bOpen Tools: Prompts, Skills & AI Agents
 
-**A shared toolkit for Claude Code, Codex, and Grok Build** with specialist
+**A shared toolkit for Claude Code, Codex, Grok Build, and OpenCode** with specialist
 agents, skills, orchestration patterns, safety hooks, and reusable
 development workflows.
 
@@ -14,10 +14,12 @@ This repository provides:
 
 - **Specialized AI agents** for design, security, documentation, architecture,
   testing, payments, infrastructure, and more
-- **Cross-agent skills** shared by Claude Code, Codex, and Grok Build
+- **Cross-agent skills** shared by Claude Code, Codex, Grok Build, and OpenCode
+  (`SKILL.md` is drop-in on OpenCode — it also reads `.claude/skills/`)
 - **Runtime-specific hooks** that preserve the same safety and workflow intent
   on Claude Code (`claude-hooks.json`), Codex (`codex-hooks.json`), and Grok
-  Build (`hooks/hooks.json`)
+  Build (`hooks/hooks.json`). OpenCode has no hooks file — the equivalent is a
+  plugin event handler (`.opencode/plugin(s)/*.ts`)
 - **Agent Master setup UI** for auditing the local harness, viewing purchased
   packs, opening advertised skill interfaces, and building runtime-specific
   setup plans without silently installing anything
@@ -756,10 +758,11 @@ Codex adapter IDs according to the current host:
 
 ### Orchestration: main seat, workers, advisor
 
-Use the `orchestrator` skill when the current Claude Code, Codex, or Grok
-Build main should retain the plan, judgment, verification, and git ownership
+Use the `orchestrator` skill when the current Claude Code, Codex, Grok
+Build, or OpenCode main should retain the plan, judgment, verification, and git ownership
 while other lanes do bounded work. Grok Build also ships a native `workflow`
-tool (Rhai scripts, `/workflows` dashboard). Codex does not.
+tool (Rhai scripts, `/workflows` dashboard). Codex and OpenCode do not — they
+sequence `codex exec` / `opencode run` dispatches from the caller.
 
 ```text
 Use $orchestra:orchestrator. Keep this session in the main seat, use native
@@ -784,11 +787,17 @@ does not pin or rename it. The supporting skills divide responsibilities:
   external lane from Claude or Codex, pin `grok-4.6`. Override that with
   `BOPEN_WORKER_MODEL`. Luna extra-high is `codex exec -m gpt-5.6-luna -c
   model_reasoning_effort="xhigh"` only when the user asked for leftover or
-  unlimited-feeling volume. Muse is `muse exec --model muse-spark-1.3`.
+   unlimited-feeling volume. Muse is `muse exec --model muse-spark-1.3`, or via
+   OpenCode as `opencode run -m muse-spark/muse-spark-1.3` with a custom provider
+   block. OpenCode workers are `opencode run --model <provider/model>` (there is
+   no `opencode exec`); OpenCode skills are drop-in `SKILL.md` and agents live in
+   `.opencode/agent(s)/`.
 - `advisor` packages a narrow, read-only consult. From a Codex main it can use
   the Claude CLI with the `fable` model-family alias. Override it with
   `BOPEN_ADVISOR_MODEL`. Fable `--safe-mode` appends
   `~/.claude/communication.md` into the system prompt. Missing file is a fail.
+  A fifth channel, `opencode run --model <provider/model>`, covers cheap or
+  in-harness consults (including Muse Spark 1.3 via OpenCode).
 - `orchestrator` composes native specialists, Coordinator, Advisor, and staged
   waves while leaving final decisions with the main session.
 - `visual-coordinator` draws an editable graph of the job (nodes, labeled
@@ -803,7 +812,9 @@ External lanes cross provider boundaries. A Grok dispatch can send its prompt,
 specification, and selected repository content to xAI. A Muse dispatch can send
 the same class of content to Meta. A Codex / Sol / Luna dispatch can send it to
 OpenAI. A Fable consult can send its consult and files inspected by read-only
-tools to Anthropic. State what will be shared before first use, obtain approval
+tools to Anthropic. An `opencode run` dispatch can send its prompt and repository
+content to whichever provider backs the pinned `provider/model` — confirm the
+`opencode.json` provider block first so the destination is known. State what will be shared before first use, obtain approval
 unless the user already authorized that lane, and never send secrets or
 unrelated proprietary content.
 

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
-  "version": "0.1.16",
-  "description": "Multi-agent orchestration for Claude Code, Grok and Codex: worker dispatch, second opinions, wave fan-out, and autonomous loops",
+  "version": "0.1.17",
+  "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",
     "url": "https://github.com/b-open-io"

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestra",
-  "version": "0.1.16",
-  "description": "Multi-agent orchestration for Claude Code, Grok and Codex: worker dispatch, second opinions, wave fan-out, and autonomous loops",
+  "version": "0.1.17",
+  "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",
     "url": "https://github.com/b-open-io"

--- a/modules/orchestra/skills/advisor/SKILL.md
+++ b/modules/orchestra/skills/advisor/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: advisor
-version: 0.0.4
+version: 0.0.5
 description: >-
   Get an independent read-only second opinion at a commitment boundary, before substantive work
   on a hard task, when stuck or changing approach, or at a final review gate. Use for "consult
-  the advisor", "get a second opinion", "ask codex", "ask Fable", or "ask a bigger model". The
+  the advisor", "get a second opinion", "ask codex", "ask Fable", "ask opencode", or "ask a bigger model". The
   advisor returns guidance; the main session keeps execution and decision ownership.
 ---
 
@@ -32,7 +32,7 @@ consult package must stand alone.
 
 ## Choosing the Advisor Channel
 
-Four channels. Detect the current host and what exists before picking; never
+Five channels. Detect the current host and what exists before picking; never
 assume.
 
 | Channel | How it works | Prefer when |
@@ -41,6 +41,7 @@ assume.
 | **Native advisor tool** | Claude Code's built-in advisor (`/advisor`, `advisorModel` setting, `--advisor` flag): the executor consults a stronger Claude model mid-turn, server-side | The advisor should be a Claude model and the account has capacity for it |
 | **Premium Claude subagent** | Spawn a read-only `Agent` (Read/Grep/Glob only) pinned to a stronger Claude model; it inspects the repo fresh and returns a verdict | The advisor should be Claude AND the question needs repo inspection the transcript doesn't carry |
 | **Fable CLI from Codex** | Run a clean, read-only Claude Code print session using the configurable `fable` model-family alias | The main is Codex and an independent Claude opinion is valuable, especially for Claude-specific work |
+| **opencode as advisor** | Dispatch a read-only consult via `opencode run --model <provider/model>` | The advisor should be a cheap or independent provider (e.g. Muse Spark 1.3, Luna) reachable through OpenCode, or the main is OpenCode and the consult should stay in-harness |
 
 Passive detection depends on the host:
 
@@ -61,13 +62,18 @@ Passive detection depends on the host:
    session model without erroring.
 5. No channel available at all? Don't silently proceed unadvised — offer to
    enable one (the codex install/auth steps live in the coordinator skill's
-   "Enabling a lane" section).
+   "Enabling a lane" section; OpenCode installs via `npm i -g opencode` plus
+   `opencode auth login` or an `opencode.json` provider block).
 6. Present the finding and recommendation to the user before first use —
    "codex is installed; recommend it as advisor" or "advisorModel is already
    set to X; using the native tool" or "Claude CLI is authenticated; recommend
-   the Fable lane" — and let them override. When multiple channels exist and
+   the Fable lane" or "opencode is installed with provider Y; recommend the
+   opencode lane" — and let them override. When multiple channels exist and
    the user has not expressed a preference, ask once, then keep the answer for
    the session.
+7. On an OpenCode main (`OPENCODE=1` / `OPENCODE_PID`), the opencode channel is
+   the in-harness default; external CLIs (`codex exec`, `claude --print`) are
+   shell-out consults with the same advice contract.
 
 From a Claude main, avoid launching another `claude -p` process unless the user
 asks; the native advisor or a native subagent is cleaner. The deliberate
@@ -180,6 +186,34 @@ unavailable. Do not silently replace Fable with a different advisor.
   follow-ups than a cold start each time.
 - Demand structure or risk silence — an uninstructed codex run can return
   nothing. Use the advice contract below in every consult prompt.
+
+### opencode-as-advisor notes
+
+- **Read-only is correct here.** The advisor advises; it must not edit.
+  Constrain the consult with permissions (`--agent` a read-only subagent where
+  available, or a prompt that says "advisory only, no edits") and keep the
+  advice contract below in every consult prompt — same silence risk as codex.
+- There is no `opencode exec`. The consult entrypoint is `opencode run`:
+
+```bash
+ADVISOR_MODEL="<provider>/<model>"   # e.g. muse-spark/muse-spark-1.3; pin explicitly
+PROMPT_FILE="/absolute/path/to/prepared-advisor-consult.md"
+
+opencode run --model "$ADVISOR_MODEL" --dir <repo> "$(cat "$PROMPT_FILE)"
+```
+
+  Attach evidence with `-f/--file`, reuse a running server with
+  `--attach http://localhost:4096` to skip MCP cold-boot, and use
+  `--format json` when scripting the verdict out.
+- Preflight `command -v opencode` plus `opencode models <provider>` for the
+  pinned id. Custom providers (Muse Spark, Luna) live as `provider:{}` blocks
+  in `opencode.json` — confirm the block exists so the data destination is
+  known before the first consult.
+- This is an external data boundary. The consult file and any repository files
+  the run inspects can be sent to the pinned provider. Disclose and obtain
+  approval before the first consult, excluding secrets and unrelated content.
+- Resume with `-c/--continue` or `-s <session-id> --fork` for follow-up
+  consults on one thread rather than cold starts.
 
 ### The advice contract (all channels)
 

--- a/modules/orchestra/skills/coordinator/SKILL.md
+++ b/modules/orchestra/skills/coordinator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: coordinator
-version: 0.0.12
+version: 0.0.13
 description: >-
-  Route bounded code-writing volume from a capable Claude Code, Codex, or Grok
-  Build main session to cheaper or specialized executors — native plugin-roster
+  Route bounded code-writing volume from a capable Claude Code, Codex, Grok
+  Build, or OpenCode main session to cheaper or specialized executors — native plugin-roster
   agents, Grok subagents, Codex / GPT-5.6 Sol workers or reviewers, GPT-5.6 Luna
-  extra-high volume, or Muse Spark 1.3 — while planning, design intent, review,
+  extra-high volume, Muse Spark 1.3, or `opencode run` workers — while planning, design intent, review,
   verification, and git stay in the main seat. Use for "dispatch to workers",
   "plan big execute small", "race worker lanes", "model arbitrage",
   "spec and dispatch", "use Sol as a worker", "use Sol as a reviewer",
@@ -18,7 +18,7 @@ description: >-
 
 Capable main-model tokens are best spent on judgment while cheaper or more
 specialized executors handle bounded code volume. This pattern works from a
-Claude Code, Codex, or Grok Build main session. Never infer or pin the main
+Claude Code, Codex, Grok Build, or OpenCode main session. Never infer or pin the main
 model: "Here" means the current main session selected by the user.
 
 **You ARE the main seat.** The main owns the plan, interfaces, review,
@@ -53,7 +53,8 @@ in parallel.
 | **grok** (Grok Build CLI, headless) | Default external quality volume when the host is Claude or Codex. Pin `BOPEN_WORKER_MODEL` |
 | **GPT-5.6 Luna @ extra-high** | Unlimited-feeling volume on leftover Codex/OpenAI quota (Replit Free Mode is the same model). `codex exec -m gpt-5.6-luna -c model_reasoning_effort="xhigh"`. Extra-high — community also uses `max` — is what makes Luna a worker. Luna at none/low/medium is the wrong recipe. **Not the default.** Do not pick Luna silently when Grok or Sol is available unless the user asked for quota or unlimited-feeling volume |
 | **Muse Spark 1.3** (Muse Code CLI) | Cheap Meta volume. Headless `muse exec --prompt-file … --model muse-spark-1.3`. Pin 1.3 — the CLI default may still be 1.2. **Not the default** |
-| **Native Workflow** | Deterministic staged fan-outs. Claude Code: `Workflow` (JS, `pipeline` + `parallel`). Grok Build: `workflow` (Rhai, `parallel` barrier only). Author on Grok with bundled `/create-workflow` — that skill is not in this plugin. Codex: none. See `references/native-workflows.md` |
+| **opencode** (OpenCode CLI, headless) | Portable worker lane from any host. `opencode run --model <provider/model> "<one-liner; details in SPEC-*.md>"`. Skills load drop-in from `.claude/skills/`; agents live in `.opencode/agent(s)/`; hooks have no file equivalent — they are plugin event handlers. See dispatch shape below |
+| **Native Workflow** | Deterministic staged fan-outs. Claude Code: `Workflow` (JS, `pipeline` + `parallel`). Grok Build: `workflow` (Rhai, `parallel` barrier only). Author on Grok with bundled `/create-workflow` — that skill is not in this plugin. Codex: none. OpenCode: no native workflow primitive — sequence `opencode run` dispatches from the caller. See `references/native-workflows.md` |
 
 Before dispatching to `general-purpose`, match the unit against the roster in
 `skills/deploy-agent-team/references/agent-roster.md` and pass the specific
@@ -78,7 +79,9 @@ the host returns `Unknown Task.model slug`. If the custom id is missing,
 use `codex exec -m gpt-5.6-sol`. On a Codex main, prefer native Codex agents and
 use Grok only for external implementation volume — do not launch another
 Codex CLI to reproduce work a native agent can do. On a Claude main, native
-Claude agents, Grok, and an external Codex/Sol lane are all valid. Any
+Claude agents, Grok, an external Codex/Sol lane, and `opencode run` workers are all valid. On an OpenCode main,
+native OpenCode subagents (`--agent <name>`) come first; external CLIs
+(`codex exec`, `grok`, `muse exec`, `claude --print`) are shell-out lanes. Any
 headless coding CLI backed by a suitable quota fits the CLI slot; ask once
 when the user's preference is ambiguous, then keep it stable for the session.
 That slot is how Luna and Muse enter — named cheap-volume options, not inferred
@@ -133,6 +136,12 @@ machine; confirm before running, re-run the preflight after):
   script before piping it). Auth: interactive `muse` browser login, or
   `META_API_KEY` for headless. Verify `muse --version` and that
   `--model muse-spark-1.3` is accepted.
+- **opencode**: `npm i -g opencode` (or `brew install opencode`, `curl -fsSL https://opencode.ai/install | bash`).
+  Auth per provider (`opencode auth login`, env keys, or `opencode.json` provider blocks).
+  Verify `opencode --version` and `opencode models <provider>` lists the intended
+  `provider/model`. Skills are drop-in (`SKILL.md` discovery includes
+  `.claude/skills/`); agents are `.opencode/agent(s)/<name>.md` or `agent:{}` in
+  `opencode.json`; there is no hooks file — hooks are plugin event handlers.
 
 **codex: plugin vs raw CLI.** Detect once per session and prefer the plugin:
 
@@ -233,6 +242,33 @@ grok --prompt-file "$PROMPT_FILE" -m "$WORKER_MODEL" --permission-mode acceptEdi
   failure. No timeout binary? Dispatch unwrapped and rely on background-job
   monitoring. If a flag misbehaves, re-check `grok --help`.
 
+**opencode (OpenCode CLI) dispatch shape (from a Claude, Codex, or Grok host):**
+```bash
+PROMPT_FILE=$(mktemp -t opencode-prompt.XXXXXX)   # unique per dispatch — parallel lanes on a shared path corrupt each other
+printf '%s\n' "<one-line imperative; details in SPEC-*.md>" > "$PROMPT_FILE"
+opencode run --model "<provider>/<model>" --dir <repo> "$(cat "$PROMPT_FILE")" \
+  > /tmp/dispatch-<id>.log 2>&1 &
+```
+- There is no `opencode exec`. The headless entrypoint is `opencode run`
+  (positional message, stdin prepended, `-f/--file` attachments,
+  `--dir` working directory, `--format json` for scripting,
+  `--attach http://localhost:4096` to reuse a running server and skip MCP cold-boot).
+- Preflight `command -v opencode`, `opencode --version`, and
+  `opencode models <provider>` for the intended `provider/model` (e.g.
+  custom `muse-spark/muse-spark-1.3` or `gpt-luna/gpt-luna` provider blocks in
+  `opencode.json`). Pin `provider/model` explicitly every time — never ride
+  the configured default.
+- For cheap Meta volume through OpenCode, register Muse Spark 1.3 as a custom
+  OpenAI-compatible provider in `opencode.json` and dispatch
+  `opencode run -m muse-spark/muse-spark-1.3`. For the unlimited-feeling lane,
+  register Luna the same way. Model refs are always `provider-id/model-id`.
+- Subagents: `.opencode/agent(s)/<name>.md` (or `agent:{}` in `opencode.json`)
+  with `mode: subagent`; invoke with `--agent <name>`. Skills are drop-in
+  `SKILL.md` (OpenCode also reads `.claude/skills/`). There is no hooks file —
+  hooks are plugin event handlers, not a dispatch surface.
+- Capture full output to a log file, demand the FINAL REPORT in the prompt,
+  and re-run acceptance in the main seat — same as every other CLI lane.
+
 Native subagent workers get a fully self-contained prompt unless the host
 explicitly guarantees inherited context. Include the spec content (or its
 path), acceptance command, and the final-report demand below, exactly as for
@@ -306,7 +342,8 @@ nothing — five nodes where one loop would ship is pure loss dressed as rigor.
 **What makes this pattern pay is the price gap, not the graph.** Coordinator
 dispatch is justified only when the executor is materially cheaper, or genuinely
 more specialized, than the main seat: bounded code volume routed to a cheap
-worker (a Grok subagent, GPT-5.6 Sol, Luna extra-high, Muse Spark 1.3, or a
+  worker (a Grok subagent, GPT-5.6 Sol, Luna extra-high, Muse Spark 1.3, an
+  `opencode run` worker on a pinned provider/model, or a
 lower-tier native agent) while premium judgment — plan, interfaces, review,
 git — stays on the expensive seat. With a real price gap, even a 5–15× token
 multiplier on the *cheap* side is a net win,
@@ -530,7 +567,7 @@ here, and keep dispatching. Strikes are about the actual implementation.
 | "More, smaller dispatches = cheaper" | Each dispatch has a floor cost. Over-fragmenting raises the bill and multiplies review surface. |
 | "This code block in my plan is nearly done, I'll just finish it" | A code block longer than an interface signature or a few illustrative lines is a spec that hasn't been delegated yet. Stop and dispatch it. |
 | "Quicker to fix the worker's bug myself" | Same failure in disguise — the main session quietly absorbing volume. Send a corrected spec back to the lane. |
-| "grok/codex isn't installed, I'll implement meanwhile" | That's a silent fallback. Report the lane unavailable, re-route explicitly, and only absorb work via the escape hatch. |
+| "grok/codex/opencode isn't installed, I'll implement meanwhile" | That's a silent fallback. Report the lane unavailable, re-route explicitly, and only absorb work via the escape hatch. |
 | "Luna is free so it's the default worker" | Luna extra-high is the unlimited-feeling volume lane when the user asked for quota/cheap Codex volume. Grok/Sol stay the quality default. |
 
 ## Common Mistakes

--- a/modules/orchestra/skills/coordinator/references/native-workflows.md
+++ b/modules/orchestra/skills/coordinator/references/native-workflows.md
@@ -1,12 +1,13 @@
 # Native Workflows
 
-Two hosts ship a first-class workflow engine. Codex does not.
+Three hosts ship a first-class workflow engine. Codex and OpenCode do not.
 
 | Host | Tool | Script | Native models | Fan-out primitive |
 |---|---|---|---|---|
 | Claude Code | `Workflow` | JavaScript | Claude aliases / ids | `pipeline()` (no barrier) and `parallel()` (barrier) |
 | Grok Build | `workflow` | Rhai | `workflow` / `spawn_subagent` slugs: `grok-4.6` only (host also lists `grok-4.5`; do not use it). Custom ids work on `grok --single -m`, not on `agent().model` | `parallel()` only — it is a barrier. There is no `pipeline()` |
 | Codex | none | — | — | Subagent spawn and `codex exec` sequenced by the caller |
+| OpenCode | none | — | `provider/model` refs per agent | Subagent dispatch (`--agent <name>`) and `opencode run` sequenced by the caller |
 
 The check is the session tool set, not memory: the host either exposes `Workflow` / `workflow` or it does not. When it does not, use the coordinator's manual dispatch protocol.
 
@@ -63,7 +64,8 @@ Grok.
 On a Grok session, load that bundled skill to author and smoke-check. Then
 apply this file's routing rules (native `grok-4.6` only, Sol/Fable as
 shell-outs, coordinator ownership). On Claude, author a JavaScript workflow
-directly. On Codex, do not author a workflow.
+directly. On Codex and OpenCode, do not author a workflow — sequence
+`codex exec` / `opencode run` dispatches from the caller instead.
 
 Verified 2026-08-13 while authoring `fable-sol-review`:
 
@@ -135,6 +137,22 @@ Author on Grok with bundled `/create-workflow`. Smoke-check with `{ validate_onl
 ## Claude script shape
 
 JavaScript, top-level `await`. `agent(prompt, { label, phase, agentType, model, effort, schema, isolation })`, `pipeline(items, ...stages)`, `parallel(thunks)`, `phase(title)`, `log(msg)`, globals `args` and `budget`. Concurrency caps at 16. Resume is same-session and follows start-order replay: every agent that started after the first unfinished one reruns. Read `<transcriptDir>/journal.jsonl` before diagnosing an empty result.
+
+## OpenCode dispatch shape (no native workflow)
+
+OpenCode has no workflow primitive. Fan-out is caller-sequenced `opencode run`
+invocations, one per unit, with the coordinator owning barriers:
+
+- Native subagents: `.opencode/agent(s)/<name>.md` with `mode: subagent`
+  (or `agent:{}` in `opencode.json`); dispatch with `opencode run --agent <name>`.
+  Subagents without an explicit `model` inherit the invoker's model.
+- Headless lane: `opencode run --model <provider/model> --dir <repo> "<task>"`
+  with `--format json` for scripting and `--attach <server>` to reuse a running
+  `opencode serve` across dispatches. There is no `opencode exec`.
+- Skills are drop-in `SKILL.md` (OpenCode also reads `.claude/skills/` and
+  `.agents/skills/`). Hooks have no file equivalent — they are plugin event
+  handlers, not a dispatch surface.
+- Host marker for the detector: `OPENCODE=1` (`OPENCODE_PID` also set).
 
 ## What the main seat keeps
 

--- a/modules/orchestra/skills/orchestrator/SKILL.md
+++ b/modules/orchestra/skills/orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: orchestrator
-version: 0.0.6
+version: 0.0.7
 description: >-
   Coordinate native specialist agents, external implementation workers such as Grok, Sol,
-  Luna extra-high, or Muse Spark 1.3, and an independent advisor such as Fable from a capable
+  Luna extra-high, Muse Spark 1.3, or `opencode run` workers, and an independent advisor such as Fable from a capable
   main session. Use for "orchestrate this", "use Grok workers", "use Luna workers",
   "use Fable as advisor", "Codex main with workers", "delegate implementation but keep
   control here", or cross-model workflows. Never replaces the user's current main model.
@@ -13,13 +13,13 @@ description: >-
 # Orchestrator
 
 Keep one main seat in control while using other agents for the work they do
-best. This skill supports both Claude Code and Codex. The current main model is
+best. This skill supports Claude Code, Codex, Grok Build, and OpenCode mains. The current main model is
 whatever the user selected; never infer, rename, or pin it.
 
 ## Default topology
 
 ```text
-Current Claude or Codex main
+Current Claude, Codex, Grok, or OpenCode main
 ├── native specialist agents: exploration, review, testing, domain expertise
 ├── worker lane: bounded implementation volume (menu, not one model)
 └── Fable advisor lane: read-only second opinions at commitment boundaries
@@ -30,6 +30,9 @@ Worker model is Coordinator's menu, never inferred:
 - **Quality default:** Grok (`BOPEN_WORKER_MODEL`) or GPT-5.6 Sol
 - **Unlimited-feeling volume, not the default:** GPT-5.6 Luna at extra-high reasoning
 - **Cheap Meta volume, not the default:** Muse Spark 1.3 via Muse Code (`muse exec`)
+  or via OpenCode (`opencode run -m muse-spark/muse-spark-1.3` with a custom provider block)
+- **Portable worker lane:** `opencode run --model <provider/model>` from any main —
+  OpenCode skills are drop-in `SKILL.md`, agents are `.opencode/agent(s)/` or `--agent <name>`
 
 Do not pin Fable as the main. The main is whatever the user already selected.
 Do not pick Luna because it is cheap; pick it when the user wants leftover /
@@ -97,6 +100,19 @@ an advisor. Coordinator governs execution; Advisor governs judgment consults.
 - Prefer Claude's native advisor or a read-only premium Claude subagent when
   available. Use an external advisor only when it adds independence.
 
+### OpenCode main
+
+- Prefer native OpenCode subagents (`.opencode/agent(s)/<name>.md`, `--agent <name>`)
+  for specialists. Skills are drop-in `SKILL.md` — OpenCode also reads `.claude/skills/`.
+- Use `opencode run --model <provider/model>` workers for bounded implementation
+  volume, and external CLIs (`codex exec`, `grok`, `muse exec`, `claude --print`)
+  as shell-out lanes when authorized. Same ownership rules: specs here, review
+  here, git here.
+- There is no native workflow primitive and no hooks file on OpenCode — sequence
+  `opencode run` dispatches from the caller, and hooks are plugin event handlers.
+- Detect the host with `OPENCODE=1` / `OPENCODE_PID` (see Coordinator and
+  `detect-harness.sh`); never assume the main from memory.
+
 ## External data boundaries
 
 External lanes are optional and must be transparent:
@@ -107,6 +123,9 @@ External lanes are optional and must be transparent:
 - A Codex / Sol / Luna dispatch can send it to OpenAI.
 - A Fable consult can send its consult package and repository files inspected
   by read tools to Anthropic.
+- An `opencode run` worker dispatch can send its prompt, specification, and
+  repository content to whichever provider backs the pinned `provider/model`
+  (configure custom providers explicitly in `opencode.json` so the destination is known).
 
 Before the first use of each external lane, state what content will be shared
 and obtain approval unless the user already explicitly authorized that lane
@@ -127,12 +146,15 @@ or a broader repository snapshot than the assignment needs.
    complete `grok models` output, require `BOPEN_WORKER_MODEL`, and confirm its
    exact value exists before dispatch. For Luna, confirm `codex` and
    `-m gpt-5.6-luna` with extra-high effort. For Muse, confirm `muse` and
-   `--model muse-spark-1.3`. For Fable, verify
+   `--model muse-spark-1.3`. For OpenCode workers, confirm `opencode` and
+   `opencode models <provider>` listing the pinned `provider/model` (no
+   `opencode exec` exists — the entrypoint is `opencode run`). For Fable, verify
    Claude CLI authentication and use
    `${BOPEN_ADVISOR_MODEL:-fable}` without claiming that alias is permanently
    the latest model.
 4. **Disclose external sharing.** Obtain any required approval before sending
-   repository content to xAI, OpenAI, Meta, or Anthropic.
+   repository content to xAI, OpenAI, Meta, Anthropic, or the provider behind
+   a pinned OpenCode `provider/model`.
 5. **Gather specialist evidence.** Use native agents for independent research,
    architecture, security, testing, documentation, or domain analysis. Give
    each a bounded, self-contained assignment and require a complete report —

--- a/modules/orchestra/skills/visual-coordinator/references/harness-capabilities.md
+++ b/modules/orchestra/skills/visual-coordinator/references/harness-capabilities.md
@@ -118,6 +118,29 @@ single-shot: one prompt, one run, no phases.
 **Render Codex as a flat subagent roster, not a pipeline.** A DAG canvas for
 Codex would imply sequencing machinery that does not exist.
 
+## OpenCode — subagents + `opencode run`, no workflows
+
+Verified 2026-09-03 against `opencode` 1.18.20 (`opencode run --help`,
+live docs at `opencode.ai/docs`). OpenCode has no workflow, pipeline, or DAG
+verb and no hooks file. `opencode run` is single-shot: one prompt, one run,
+no phases. There is no `opencode exec`.
+
+| Capability | Detail |
+|---|---|
+| Orchestration | Subagent dispatch (`--agent <name>`) plus caller-sequenced `opencode run` |
+| Headless | `opencode run "<task>"` (positional message, stdin prepended, `-f/--file` attachments, `--dir` cwd, `--format json` for scripting, `--attach <server>` to reuse `opencode serve`, `--auto` to auto-approve non-denied permissions) |
+| Custom agents | `.opencode/agent(s)/<name>.md` (project) or `~/.config/opencode/agent(s)/` (global); filename is the agent name, body is the prompt; `mode: subagent`, `permission:` per agent. Inline `agent:{}` in `opencode.json` also works |
+| Per-agent model | `provider/model` refs (`-m/--model`, per-agent `model:`, per-command `model:`). Subagents without explicit `model` inherit the invoker's model |
+| Custom providers | `provider:{}` blocks in `opencode.json` (`npm: @ai-sdk/openai-compatible`, `baseURL` ending at `/v1`, key via `{env:VAR}`); verify with `opencode models <provider>` |
+| Skills | Drop-in `SKILL.md` — OpenCode also reads `.claude/skills/` and `.agents/skills/`; `name` must equal the directory name |
+| Hooks | No hooks file — plugin event handlers (`.opencode/plugin(s)/*.ts`, `tool.execute.before/after`, `permission.asked`, `session.*`) |
+| Commands | `.opencode/command(s)/<name>.md`; headless via `opencode run --command <name>` |
+
+**Render OpenCode as a flat subagent roster plus `opencode run` shell-out
+nodes, not a pipeline.** Same rule as Codex.
+
+Host marker for the detector: `OPENCODE=1` (`OPENCODE_PID` also set).
+
 ## Model identifiers
 
 Discover rather than assume; `scripts/detect-harness.sh` does this.
@@ -129,6 +152,9 @@ Discover rather than assume; `scripts/detect-harness.sh` does this.
   truth. The in-app picker has lagged behind what `-m` accepts.
 - **Grok**: whatever `grok models` prints for the authenticated account, plus
   any custom `[model.<alias>]` the user registered.
+- **OpenCode**: whatever `opencode models <provider>` prints for the configured
+  providers, referenced as `provider/model`. Custom Muse Spark / Luna lanes are
+  `provider:{}` blocks in `opencode.json` — never assume the id without listing it.
 
 ## Shell-out invocations for cross-provider nodes
 
@@ -149,6 +175,10 @@ grok --prompt-file <file> -m gpt-5.6-sol \
 claude --print --safe-mode --append-system-prompt-file "$HOME/.claude/communication.md" \
   --model "${BOPEN_ADVISOR_MODEL:-fable}" \
   --permission-mode plan --tools "Read,Grep,Glob" --no-session-persistence
+
+# opencode worker — no `opencode exec` exists; `opencode run` is the entrypoint
+opencode run --model "<provider>/<model>" --dir <repo> "$(cat <file>)" \
+  > /tmp/dispatch-<id>.log 2>&1 &
 ```
 
 Two caveats worth putting in front of the user:
@@ -164,7 +194,8 @@ in the wrapped process, not the wrapper.
 1. That a Claude workflow step can run a Grok or GPT model natively. It cannot.
 2. That a Grok native node can run an id `grok models` does not list. Register it first, or emit a shell-out.
 3. That Codex has a workflow. It has subagents.
-4. That "hundreds of parallel agents" is a Grok specification. Default budget is 128.
-5. That a resumed Claude workflow preserves all completed agents. See the replay rule.
-6. That Grok has `pipeline()`. It has barrier `parallel()` only.
-7. That `/create-workflow` exists on Claude or Codex. It is a Grok-bundled skill only.
+4. That OpenCode has a workflow or an `exec` subcommand. It has subagents and `opencode run`.
+5. That "hundreds of parallel agents" is a Grok specification. Default budget is 128.
+6. That a resumed Claude workflow preserves all completed agents. See the replay rule.
+7. That Grok has `pipeline()`. It has barrier `parallel()` only.
+8. That `/create-workflow` exists on Claude, Codex, or OpenCode. It is a Grok-bundled skill only.

--- a/modules/orchestra/skills/visual-coordinator/scripts/detect-harness.sh
+++ b/modules/orchestra/skills/visual-coordinator/scripts/detect-harness.sh
@@ -17,6 +17,8 @@ json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n'; }
 harness="unknown"
 if [[ -n "${GROK_AGENT:-}" || -n "${GROK_SANDBOX:-}" || -n "${GROK_HOME:-}" ]]; then
   harness="grok"
+elif [[ -n "${OPENCODE:-}" || -n "${OPENCODE_PID:-}" ]]; then
+  harness="opencode"
 elif [[ -n "${CLAUDECODE:-}" || -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
   harness="claude-code"
 elif [[ -n "${CODEX_HOME:-}" || -n "${CODEX_SANDBOX:-}" ]]; then
@@ -33,6 +35,7 @@ lane_status() {
 claude_bin=$(lane_status claude)
 codex_bin=$(lane_status codex)
 grok_bin=$(lane_status grok)
+opencode_bin=$(lane_status opencode)
 
 # --- Models actually offered, not models we assume ---------------------------
 # grok enumerates per authenticated account plus quoted [model."id"] blocks.
@@ -59,6 +62,26 @@ if [[ -f "${CODEX_HOME:-$HOME/.codex}/config.toml" ]]; then
   codex_model=$(grep -m1 '^model *=' "${CODEX_HOME:-$HOME/.codex}/config.toml" 2>/dev/null | sed 's/.*= *//; s/"//g')
 fi
 
+# opencode enumerates per configured provider: `opencode models <provider>`.
+# Without a provider arg the output shape varies, so report the configured
+# default model from opencode.json plus a best-effort id list. Never fail.
+opencode_model=""
+for _cfg in "$PWD/opencode.json" "$HOME/.config/opencode/opencode.json"; do
+  if [[ -f "$_cfg" ]]; then
+    _m=$(grep -m1 '"model"' "$_cfg" 2>/dev/null | sed 's/.*: *//; s/"//g; s/,//g; s/ //g')
+    if [[ -n "$_m" ]]; then opencode_model="$_m"; break; fi
+  fi
+done
+unset _cfg _m
+opencode_models=""
+if [[ "$opencode_bin" == "available" ]]; then
+  opencode_models=$(opencode models 2>/dev/null \
+    | sed -n 's/^[[:space:]]*\([A-Za-z0-9._:\/-]*\).*/\1/p' \
+    | awk 'NF && !seen[$0]++' \
+    | head -40 \
+    | paste -sd, -)
+fi
+
 # --- Caps the canvas must honour --------------------------------------------
 native_workflow="false"
 live_children=6
@@ -67,6 +90,7 @@ case "$harness" in
   claude-code) native_workflow="true"; live_children=16; agent_budget=1000 ;;
   grok)        native_workflow="true"; live_children=32; agent_budget=128 ;;
   codex)       native_workflow="false"; live_children=6; agent_budget=0 ;;
+  opencode)    native_workflow="false"; live_children=6; agent_budget=0 ;;
 esac
 
 # --- Installed roster --------------------------------------------------------
@@ -147,6 +171,13 @@ codex_models_json=""
 if [[ -n "$codex_model" ]]; then
   codex_models_json="\"$(json_escape "$codex_model")\""
 fi
+opencode_models_json=$(printf '%s' "$opencode_models" | awk -F, '{for(i=1;i<=NF;i++){if($i!=""){printf "%s\"%s\"", (i>1?",":""), $i}}}')
+opencode_default_json=""
+if [[ -n "$opencode_model" ]]; then
+  opencode_default_json="\"$(json_escape "$opencode_model")\""
+else
+  opencode_default_json="null"
+fi
 
 cat <<JSON
 {
@@ -159,7 +190,8 @@ cat <<JSON
   "lanes": {
     "claude": "$claude_bin",
     "codex": "$codex_bin",
-    "grok": "$grok_bin"
+    "grok": "$grok_bin",
+    "opencode": "$opencode_bin"
   },
   "models": {
     "claude": ["opus", "sonnet", "haiku", "fable", "inherit"],
@@ -167,7 +199,9 @@ cat <<JSON
     "grok": [${grok_models_json}],
     "grok_effort": ["none", "minimal", "low", "medium", "high", "xhigh"],
     "codex": [${codex_models_json}],
-    "codex_effort": ["minimal", "low", "medium", "high", "xhigh"]
+    "codex_effort": ["minimal", "low", "medium", "high", "xhigh"],
+    "opencode": [${opencode_models_json}],
+    "opencode_default": ${opencode_default_json}
   },
   "roster": $roster_json
 }

--- a/modules/orchestra/skills/wave-coordinator/SKILL.md
+++ b/modules/orchestra/skills/wave-coordinator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-coordinator
-version: 1.0.6
+version: 1.0.7
 description: >-
   Dispatch many subagents in coordinated waves with per-wave review. Use for "fan out agents",
   "wave dispatch", "batch agents", "generate N variations", or any fan-out beyond about five
@@ -172,6 +172,15 @@ part of this skill.
 Use `/agent` or the available agent activity view to inspect active and
 completed threads. Account for already-open threads when calculating the next
 wave.
+
+### OpenCode
+
+Use native OpenCode subagents (`.opencode/agent(s)/<name>.md`, `--agent <name>`)
+with the installed roster id where one fits. There is no native workflow
+primitive — the caller sequences `opencode run --model <provider/model>`
+dispatches and owns barriers. Keep wave coordination in the main thread;
+subagents without an explicit `model` inherit the invoker's model, so pin
+`provider/model` on worker slots that must not inherit a premium main.
 
 ## Integration with superpowers
 


### PR DESCRIPTION
## What

OpenCode CLI becomes a fourth supported orchestra harness alongside Claude Code, Codex, and Grok Build — as a main seat, a worker lane, and an advisor channel. Verified against `opencode` 1.18.20 plus live docs.

Key facts driving the design:
- Headless entrypoint is `opencode run` — there is no `opencode exec`. Model refs are always `provider/model`; custom providers (Muse Spark, Luna) are `provider:{}` blocks in `opencode.json`.
- Skills are drop-in (`SKILL.md` discovery includes `.claude/skills/`). Agents live in `.opencode/agent(s)/`. Hooks have no file equivalent — they are plugin event handlers.
- Host marker: `OPENCODE=1` / `OPENCODE_PID`.

## Changes (orchestra 0.1.16 → 0.1.17, patch bumps throughout)

- `coordinator` 0.0.13: OpenCode main + `opencode run --model <provider/model>` worker row, enabling lane, dispatch shape, preflight
- `orchestrator` 0.0.7: 4-harness topology, OpenCode main adapter, data-boundary + preflight
- `advisor` 0.0.5: fifth channel — `opencode run` consult (incl. Muse Spark 1.3 via OpenCode)
- `wave-coordinator` 1.0.7: OpenCode host adapter
- `detect-harness.sh`: `OPENCODE` detection, `opencode` lane, `opencode models` + default-model reporting (syntax + live-run verified)
- `native-workflows.md` + `harness-capabilities.md`: OpenCode sections (flat dispatch, no native workflow primitive)
- Manifests, README, CHANGELOG

## Verification

- `bash -n` + live run of `detect-harness.sh` (reports `"harness": "opencode"`, all four lanes, live model list)
- `check-plugin-manifests.py` + `check-docs.py` pass
- Website + packs support ships as a separate PR in bopen-ai