### PR TITLE
OPL-4409: Correct OpenCode subagent dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ manifests share the same release version.
 
 ### Fixed
 
+- Corrected OpenCode subagent dispatch: `--agent <name>` selects a primary
+  agent and falls back when given a subagent on OpenCode 1.18.20. The tested
+  headless pattern now pins the parent model, invokes `@general`, and requires
+  a child marker in the log before counting the run as delegated. Model ids
+  remain discovery-driven. Read-only consults require a permission-constrained
+  `@name` child or a read-only primary/all-mode agent; prompt-only restrictions
+  are not treated as a boundary. `advisor` 0.0.6, `coordinator` 0.0.14,
+  `orchestrator` 0.0.8, `wave-coordinator` 1.0.8, `visual-coordinator` 0.1.7.
+  orchestra 0.1.18.
 - Optional modules installed from the b-open-io marketplace no longer ship
   dangling skill symlinks. The marketplace sources each module with
   `git-subdir`, which ships only `modules/<name>`, so the sixteen vendored

--- a/README.md
+++ b/README.md
@@ -792,9 +792,11 @@ does not pin or rename it. The supporting skills divide responsibilities:
   model_reasoning_effort="xhigh"` only when the user asked for leftover or
    unlimited-feeling volume. Muse is `muse exec --model muse-spark-1.3`, or via
    OpenCode as `opencode run -m muse-spark/muse-spark-1.3` with a custom provider
-   block. OpenCode workers are `opencode run --model <provider/model>` (there is
-   no `opencode exec`); OpenCode skills are drop-in `SKILL.md` and agents live in
-   `.opencode/agent(s)/`.
+   block. For a real OpenCode child, pin the parent model and invoke the child:
+   `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"`.
+   `--agent <name>` selects a primary/all-mode agent, not a `mode: subagent` agent.
+   Verify the model with `opencode models <provider>` and the child marker in the log;
+   a primary `build` line alone is not delegation. There is no `opencode exec`.
 - `advisor` packages a narrow, read-only consult. From a Codex main it can use
   the Claude CLI with the `fable` model-family alias. Override it with
   `BOPEN_ADVISOR_MODEL`. Fable `--safe-mode` appends

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/skills/advisor/SKILL.md
+++ b/modules/orchestra/skills/advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisor
-version: 0.0.5
+version: 0.0.6
 description: >-
   Get an independent read-only second opinion at a commitment boundary, before substantive work
   on a hard task, when stuck or changing approach, or at a final review gate. Use for "consult
@@ -190,21 +190,27 @@ unavailable. Do not silently replace Fable with a different advisor.
 ### opencode-as-advisor notes
 
 - **Read-only is correct here.** The advisor advises; it must not edit.
-  Constrain the consult with permissions (`--agent` a read-only subagent where
-  available, or a prompt that says "advisory only, no edits") and keep the
-  advice contract below in every consult prompt — same silence risk as codex.
+  Use an agent whose configuration denies edits and shell execution; a prompt
+  saying "no edits" is not a permission boundary. Invoke a `mode: subagent`
+  advisor through `@name`, or use `--agent <name>` only when that name is a
+  read-only primary/all-mode agent. Keep the advice contract below in every
+  consult prompt — same silence risk as codex.
 - There is no `opencode exec`. The consult entrypoint is `opencode run`:
 
 ```bash
 ADVISOR_MODEL="<provider>/<model>"   # e.g. muse-spark/muse-spark-1.3; pin explicitly
 PROMPT_FILE="/absolute/path/to/prepared-advisor-consult.md"
 
-opencode run --model "$ADVISOR_MODEL" --dir <repo> "$(cat "$PROMPT_FILE)"
+opencode run --model "$ADVISOR_MODEL" --dir <repo> \
+  "@<read-only-subagent> $(cat "$PROMPT_FILE")"
 ```
 
   Attach evidence with `-f/--file`, reuse a running server with
   `--attach http://localhost:4096` to skip MCP cold-boot, and use
   `--format json` when scripting the verdict out.
+- Capture the run and verify the configured advisor's child marker. A primary
+  `build` line alone does not prove the read-only child ran. OpenCode 1.18.20
+  falls back to the default primary agent when `--agent` names a subagent.
 - Preflight `command -v opencode` plus `opencode models <provider>` for the
   pinned id. Custom providers (Muse Spark, Luna) live as `provider:{}` blocks
   in `opencode.json` — confirm the block exists so the data destination is

--- a/modules/orchestra/skills/coordinator/SKILL.md
+++ b/modules/orchestra/skills/coordinator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coordinator
-version: 0.0.13
+version: 0.0.14
 description: >-
   Route bounded code-writing volume from a capable Claude Code, Codex, Grok
   Build, or OpenCode main session to cheaper or specialized executors — native plugin-roster
@@ -80,7 +80,8 @@ use `codex exec -m gpt-5.6-sol`. On a Codex main, prefer native Codex agents and
 use Grok only for external implementation volume — do not launch another
 Codex CLI to reproduce work a native agent can do. On a Claude main, native
 Claude agents, Grok, an external Codex/Sol lane, and `opencode run` workers are all valid. On an OpenCode main,
-native OpenCode subagents (`--agent <name>`) come first; external CLIs
+native OpenCode agents come first — `opencode run --agent <name>` selects a
+primary/all-mode agent, not a `mode: subagent` agent; external CLIs
 (`codex exec`, `grok`, `muse exec`, `claude --print`) are shell-out lanes. Any
 headless coding CLI backed by a suitable quota fits the CLI slot; ask once
 when the user's preference is ambiguous, then keep it stable for the session.
@@ -262,12 +263,28 @@ opencode run --model "<provider>/<model>" --dir <repo> "$(cat "$PROMPT_FILE")" \
   OpenAI-compatible provider in `opencode.json` and dispatch
   `opencode run -m muse-spark/muse-spark-1.3`. For the unlimited-feeling lane,
   register Luna the same way. Model refs are always `provider-id/model-id`.
-- Subagents: `.opencode/agent(s)/<name>.md` (or `agent:{}` in `opencode.json`)
-  with `mode: subagent`; invoke with `--agent <name>`. Skills are drop-in
-  `SKILL.md` (OpenCode also reads `.claude/skills/`). There is no hooks file —
-  hooks are plugin event handlers, not a dispatch surface.
-- Capture full output to a log file, demand the FINAL REPORT in the prompt,
-  and re-run acceptance in the main seat — same as every other CLI lane.
+- Agents: `.opencode/agent(s)/<name>.md` (or `agent:{}` in `opencode.json`).
+  `opencode run --agent <name>` selects a primary/all-mode agent — it does
+  not directly start a `mode: subagent` agent. A real child invocation is a
+  headless primary session that invokes the named child with an `@mention`:
+  `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"`.
+  The primary session invokes the named child; a subagent without its own
+  `model` inherits the parent model. OpenCode 1.18.20 logs a warning and
+  falls back to the default primary agent when `--agent` names a subagent.
+  Skills are drop-in `SKILL.md` (OpenCode also reads `.claude/skills/`).
+  There is no hooks file — hooks are plugin event handlers, not a dispatch surface.
+- Verify available models with `opencode models <provider>` rather than
+  assuming ids. The lane successfully tested here is
+  `opencode/muse-spark-1.3-contributor-free` — a verified example, not a
+  universal or permanent identifier.
+- Require dispatch evidence: capture full output to a log file and verify a
+  child marker such as `General Agent` (or the configured subagent's
+  equivalent) before treating the run as a subagent workflow. A primary
+  `build` line alone does not prove delegation. Demand the FINAL REPORT in
+  the prompt, and re-run acceptance in the main seat — same as every other
+  CLI lane.
+- OpenCode has no native multi-stage workflow engine: the caller still owns
+  sequencing and barriers.
 
 Native subagent workers get a fully self-contained prompt unless the host
 explicitly guarantees inherited context. Include the spec content (or its

--- a/modules/orchestra/skills/coordinator/references/native-workflows.md
+++ b/modules/orchestra/skills/coordinator/references/native-workflows.md
@@ -7,7 +7,7 @@ Three hosts ship a first-class workflow engine. Codex and OpenCode do not.
 | Claude Code | `Workflow` | JavaScript | Claude aliases / ids | `pipeline()` (no barrier) and `parallel()` (barrier) |
 | Grok Build | `workflow` | Rhai | `workflow` / `spawn_subagent` slugs: `grok-4.6` only (host also lists `grok-4.5`; do not use it). Custom ids work on `grok --single -m`, not on `agent().model` | `parallel()` only — it is a barrier. There is no `pipeline()` |
 | Codex | none | — | — | Subagent spawn and `codex exec` sequenced by the caller |
-| OpenCode | none | — | `provider/model` refs per agent | Subagent dispatch (`--agent <name>`) and `opencode run` sequenced by the caller |
+| OpenCode | none | — | `provider/model` refs per agent | Primary-agent `--agent <name>` plus `@mention` child invocation, `opencode run` sequenced by the caller |
 
 The check is the session tool set, not memory: the host either exposes `Workflow` / `workflow` or it does not. When it does not, use the coordinator's manual dispatch protocol.
 
@@ -143,12 +143,26 @@ JavaScript, top-level `await`. `agent(prompt, { label, phase, agentType, model, 
 OpenCode has no workflow primitive. Fan-out is caller-sequenced `opencode run`
 invocations, one per unit, with the coordinator owning barriers:
 
-- Native subagents: `.opencode/agent(s)/<name>.md` with `mode: subagent`
-  (or `agent:{}` in `opencode.json`); dispatch with `opencode run --agent <name>`.
-  Subagents without an explicit `model` inherit the invoker's model.
-- Headless lane: `opencode run --model <provider/model> --dir <repo> "<task>"`
+- Primary vs subagent: `.opencode/agent(s)/<name>.md` with `mode: subagent`
+  (or `agent:{}` in `opencode.json`). `opencode run --agent <name>` selects a
+  primary/all-mode agent — it does not directly start a `mode: subagent`
+  agent. A real child invocation is a headless primary session invoking the
+  named child: `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"`.
+  The primary session invokes the named child; subagents without an explicit
+  `model` inherit the invoker's model. OpenCode 1.18.20 logs a warning and
+  falls back to the default primary agent when `--agent` names a subagent.
+- Require dispatch evidence: capture output and verify a child marker such
+  as `General Agent` (or the configured subagent's equivalent) before
+  treating the run as a subagent workflow. A primary `build` line alone does
+  not prove delegation.
+- Headless lane: `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"`
   with `--format json` for scripting and `--attach <server>` to reuse a running
   `opencode serve` across dispatches. There is no `opencode exec`.
+  Verify available models with `opencode models <provider>`; the lane
+  successfully tested here (`opencode/muse-spark-1.3-contributor-free`) is a
+  verified example, not a universal or permanent identifier. OpenCode has no
+  native multi-stage workflow engine — the caller still owns sequencing and
+  barriers.
 - Skills are drop-in `SKILL.md` (OpenCode also reads `.claude/skills/` and
   `.agents/skills/`). Hooks have no file equivalent — they are plugin event
   handlers, not a dispatch surface.

--- a/modules/orchestra/skills/orchestrator/SKILL.md
+++ b/modules/orchestra/skills/orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-version: 0.0.7
+version: 0.0.8
 description: >-
   Coordinate native specialist agents, external implementation workers such as Grok, Sol,
   Luna extra-high, Muse Spark 1.3, or `opencode run` workers, and an independent advisor such as Fable from a capable
@@ -31,8 +31,7 @@ Worker model is Coordinator's menu, never inferred:
 - **Unlimited-feeling volume, not the default:** GPT-5.6 Luna at extra-high reasoning
 - **Cheap Meta volume, not the default:** Muse Spark 1.3 via Muse Code (`muse exec`)
   or via OpenCode (`opencode run -m muse-spark/muse-spark-1.3` with a custom provider block)
-- **Portable worker lane:** `opencode run --model <provider/model>` from any main —
-  OpenCode skills are drop-in `SKILL.md`, agents are `.opencode/agent(s)/` or `--agent <name>`
+- **Portable worker lane:** `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"` from any main. `--agent <name>` selects a primary/all-mode agent, not a subagent
 
 Do not pin Fable as the main. The main is whatever the user already selected.
 Do not pick Luna because it is cheap; pick it when the user wants leftover /
@@ -102,14 +101,19 @@ an advisor. Coordinator governs execution; Advisor governs judgment consults.
 
 ### OpenCode main
 
-- Prefer native OpenCode subagents (`.opencode/agent(s)/<name>.md`, `--agent <name>`)
-  for specialists. Skills are drop-in `SKILL.md` — OpenCode also reads `.claude/skills/`.
-- Use `opencode run --model <provider/model>` workers for bounded implementation
-  volume, and external CLIs (`codex exec`, `grok`, `muse exec`, `claude --print`)
-  as shell-out lanes when authorized. Same ownership rules: specs here, review
-  here, git here.
+- Prefer native OpenCode agents (`.opencode/agent(s)/<name>.md`) for specialists.
+  `--agent <name>` does not start a `mode: subagent` agent; invoke the child from
+  a headless primary session:
+  `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"`.
+  Skills are drop-in `SKILL.md` — OpenCode also reads `.claude/skills/`.
+- Use `opencode run --model "<provider>/<model>"` workers for bounded
+  implementation volume, and external CLIs (`codex exec`, `grok`, `muse exec`,
+  `claude --print`) as shell-out lanes when authorized. Verify the model and a
+  child marker in the dispatch log. Coordinator owns the full dispatch contract.
+  Same ownership rules: specs here, review here, git here.
 - There is no native workflow primitive and no hooks file on OpenCode — sequence
-  `opencode run` dispatches from the caller, and hooks are plugin event handlers.
+  `opencode run` dispatches from the caller (the caller owns sequencing and
+  barriers), and hooks are plugin event handlers.
 - Detect the host with `OPENCODE=1` / `OPENCODE_PID` (see Coordinator and
   `detect-harness.sh`); never assume the main from memory.
 

--- a/modules/orchestra/skills/visual-coordinator/SKILL.md
+++ b/modules/orchestra/skills/visual-coordinator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: visual-coordinator
 description: This skill should be used when the user asks to "design the workflow visually", "show me the workflow before running it", "let me configure the agents first", "visual workflow builder", "which models for which steps", "let me pick the models", "plan this fan-out", "diagram the orchestration", or wants to review and adjust a multi-agent job — models, agents, phases, isolation — before it runs. Renders an editable graph (nodes, labeled edges, reject-back gates) the user can rewire; staffing is on the selected card. Emits a paste-back spec from the live graph. Builds on the coordinator skill; use coordinator alone when no visual review is wanted.
-version: 0.1.6
+version: 0.1.7
 ---
 
 # Visual Coordinator

--- a/modules/orchestra/skills/visual-coordinator/references/harness-capabilities.md
+++ b/modules/orchestra/skills/visual-coordinator/references/harness-capabilities.md
@@ -127,8 +127,8 @@ no phases. There is no `opencode exec`.
 
 | Capability | Detail |
 |---|---|
-| Orchestration | Subagent dispatch (`--agent <name>`) plus caller-sequenced `opencode run` |
-| Headless | `opencode run "<task>"` (positional message, stdin prepended, `-f/--file` attachments, `--dir` cwd, `--format json` for scripting, `--attach <server>` to reuse `opencode serve`, `--auto` to auto-approve non-denied permissions) |
+| Orchestration | Primary-agent `--agent <name>` plus `@mention` child invocation, caller-sequenced `opencode run` (no native multi-stage workflow engine) |
+| Headless | `opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>"` (positional message, stdin prepended, `-f/--file` attachments, `--dir` cwd, `--format json` for scripting, `--attach <server>` to reuse `opencode serve`, `--auto` to auto-approve non-denied permissions) |
 | Custom agents | `.opencode/agent(s)/<name>.md` (project) or `~/.config/opencode/agent(s)/` (global); filename is the agent name, body is the prompt; `mode: subagent`, `permission:` per agent. Inline `agent:{}` in `opencode.json` also works |
 | Per-agent model | `provider/model` refs (`-m/--model`, per-agent `model:`, per-command `model:`). Subagents without explicit `model` inherit the invoker's model |
 | Custom providers | `provider:{}` blocks in `opencode.json` (`npm: @ai-sdk/openai-compatible`, `baseURL` ending at `/v1`, key via `{env:VAR}`); verify with `opencode models <provider>` |
@@ -176,9 +176,17 @@ claude --print --safe-mode --append-system-prompt-file "$HOME/.claude/communicat
   --model "${BOPEN_ADVISOR_MODEL:-fable}" \
   --permission-mode plan --tools "Read,Grep,Glob" --no-session-persistence
 
-# opencode worker — no `opencode exec` exists; `opencode run` is the entrypoint
-opencode run --model "<provider>/<model>" --dir <repo> "$(cat <file>)" \
+# opencode worker — no `opencode exec` exists; `opencode run` is the entrypoint.
+# `--agent <name>` selects a primary/all-mode agent, not a `mode: subagent`
+# agent (1.18.20 warns and falls back to the default primary agent).
+# A real child invocation is a primary session invoking the named child.
+opencode run --model "<provider>/<model>" --dir <repo> "@general <bounded task>" \
   > /tmp/dispatch-<id>.log 2>&1 &
+# Verify models with `opencode models <provider>`; verified example (not
+# universal/permanent): `opencode/muse-spark-1.3-contributor-free`.
+# Require dispatch evidence: a child marker such as `General Agent` — a
+# primary `build` line alone does not prove delegation. A subagent without
+# its own `model` inherits the parent model.
 ```
 
 Two caveats worth putting in front of the user:

--- a/modules/orchestra/skills/wave-coordinator/SKILL.md
+++ b/modules/orchestra/skills/wave-coordinator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-coordinator
-version: 1.0.7
+version: 1.0.8
 description: >-
   Dispatch many subagents in coordinated waves with per-wave review. Use for "fan out agents",
   "wave dispatch", "batch agents", "generate N variations", or any fan-out beyond about five
@@ -175,12 +175,12 @@ wave.
 
 ### OpenCode
 
-Use native OpenCode subagents (`.opencode/agent(s)/<name>.md`, `--agent <name>`)
-with the installed roster id where one fits. There is no native workflow
-primitive — the caller sequences `opencode run --model <provider/model>`
-dispatches and owns barriers. Keep wave coordination in the main thread;
-subagents without an explicit `model` inherit the invoker's model, so pin
-`provider/model` on worker slots that must not inherit a premium main.
+Use native OpenCode agents (`.opencode/agent(s)/<name>.md`) with the installed
+roster id where one fits. `--agent <name>` selects a primary/all-mode agent,
+not a subagent; invoke a real child from the primary with `@name`, as defined
+by Coordinator. Pin and verify the parent model, then require a child marker
+in the log before counting the run as delegated. There is no native multi-stage
+workflow engine: the caller sequences dispatches and owns barriers.
 
 ## Integration with superpowers
 


### PR DESCRIPTION
## Summary

A live Muse/OpenCode lane test exposed that `opencode run --agent <name>` does not directly invoke `mode: subagent` agents on OpenCode 1.18.20; it warns and falls back to the default primary agent.

- document the working pinned-model primary → `@name` child flow
- require child-marker evidence before counting a dispatch as delegated
- preserve model discovery instead of assuming a permanent Muse id
- fix the read-only Advisor boundary so fallback cannot silently become write-capable
- bump Orchestra to 0.1.18 and affected skills by one patch

## Verification

- real Muse run produced a distinct `General Agent` child
- independent maker/checker review: accepted after one stale Advisor instruction was corrected
- `python3 scripts/check-plugin-manifests.py`
- `python3 scripts/check-docs.py`
- `python3 scripts/codex-agents/generate.py --check`
- `bash hooks/tests/run-tests.sh` — 381 passed, 0 failed
- `bash scripts/test-isolated-plugin-install.sh`
- `git diff --check`

This targets `dev`. It does not publish the plugin; the standing dev-to-master promotion keeps its 24-hour cooling period and fresh `/approve` gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791114962&installation_model_id=435537&pr_number=40&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F40&signature=2ef0ee78d9971cc47ea793cbbb3516773ab475f6b0bf5ff7aafb7ad0225ff5e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->