### PR TITLE
Restore Orchestra's cheap worker routing [OPL-4432]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ manifests share the same release version.
 
 ### Fixed
 
+- Orchestra no longer lets native-first specialist guidance absorb routine
+  implementation into the premium lane. Invoking `orchestrator` now defaults
+  bounded code volume to the cheapest authorized, preflighted capable worker,
+  while native agents remain preferred for evidence, investigation, review,
+  testing, and tool- or domain-bound judgment. The Codex, Claude, Grok, and
+  OpenCode host guides carry the same boundary. When a host supports native
+  children, each external worker now runs under a visible native controller so
+  it participates in subagent panels and workflow lifecycle without moving the
+  implementation back to the controller model. The OpenCode guide records the
+  conditional `opencode/muse-spark-1.3-contributor-free` recipe. `coordinator`
+  0.0.16, `orchestrator` 0.0.10, orchestra 0.1.20.
+- The Orchestrator Codex UI prompt now names the correct
+  `$orchestra:orchestrator` skill and asks for cheaper implementation workers.
 - Corrected OpenCode subagent dispatch: `--agent <name>` selects a primary
   agent and falls back when given a subagent on OpenCode 1.18.20. The tested
   headless pattern now pins the parent model, invokes `@general`, and requires

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This repository provides:
 - **Agent Master setup UI** for auditing the local harness, viewing purchased
   packs, opening advertised skill interfaces, and building runtime-specific
   setup plans without silently installing anything
-- **Orchestration patterns** for a strong main model, native specialists,
-  Grok implementation workers, and a read-only Fable advisor
+- **Orchestration patterns** that keep a strong main model on judgment, wrap
+  cheaper implementation workers in visible native controllers, and support a
+  read-only Fable advisor
 - **Claude Code slash commands** for common workflows
 
 See [CHANGELOG.md](CHANGELOG.md) for release notes and the reconstructed
@@ -780,10 +781,10 @@ does not pin or rename it. The supporting skills divide responsibilities:
 - `coordinator` writes precise worker specs, assigns non-overlapping files,
   dispatches implementation, and requires acceptance reports. It loads one
   shared dispatch contract, the current host guide, and only the selected
-  worker guide. Grok and GPT-5.6 Sol are quality lanes; Luna extra-high and
-  Muse Spark 1.3 are explicit cheap-volume choices; OpenCode is a portable
-  harness whose provider and model must be pinned. Unselected harness manuals
-  never enter the skill context.
+  worker guide. Bounded implementation defaults to the cheapest authorized,
+  capable lane; native specialists stay focused on evidence, review, testing,
+  and domain judgment. OpenCode is a portable harness whose provider and model
+  must be pinned. Unselected harness manuals never enter the skill context.
 - `advisor` packages a narrow, read-only consult. From a Codex main it can use
   the Claude CLI with the `fable` model-family alias. Override it with
   `BOPEN_ADVISOR_MODEL`. Fable `--safe-mode` appends

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/skills/coordinator/SKILL.md
+++ b/modules/orchestra/skills/coordinator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: coordinator
-version: 0.0.15
-description: Route bounded implementation from the current main session to native or external workers while keeping planning, review, verification, and git in the main seat. Use for worker dispatch, model arbitrage, parallel implementation, Sol, Luna, Muse, Grok, OpenCode, or native workflows.
+version: 0.0.16
+description: Route bounded implementation from a capable main session to cheaper workers while keeping planning, review, verification, and git in the main seat. Use for worker dispatch, model arbitrage, parallel implementation, Sol, Luna, Muse, Grok, OpenCode, or native workflows.
 ---
 
 # Coordinator
@@ -40,7 +40,8 @@ not load Grok, Codex, or Muse instructions.
 | Work | Owner |
 |---|---|
 | Plan, architecture, interfaces, and acceptance criteria | Main |
-| Bounded implementation | Selected worker |
+| External-worker launch, monitoring, and complete report | Native worker-controller when supported |
+| Bounded implementation | Selected cheaper worker |
 | Hard debugging analysis and visual judgment | Main, then dispatch the fix |
 | Diff review, final verification, commits, pushes, and PRs | Main |
 | One-line edits found during review | Main when dispatch overhead is larger |
@@ -51,20 +52,42 @@ API or file-ownership boundaries, not into tiny tasks merely to create a graph.
 
 ## Select a lane
 
-Prefer a native specialist on the current host when it has the required tools
-and context. Match named specialist work against
-`../deploy-agent-team/references/agent-roster.md`; use a generic worker only
-when no roster specialist fits, and say so.
+Choose implementation lanes by economics first. Preserve a user-selected cheap
+lane; otherwise use the cheapest authorized, preflighted worker that can meet
+the acceptance criteria. If provider authorization or preference is unresolved,
+ask once. Do not silently implement on the premium main or native lane.
+
+Prefer native specialists for evidence, investigation, review, testing, and
+tool- or domain-bound judgment. Match that work against
+`../deploy-agent-team/references/agent-roster.md`; use a generic specialist only
+when no roster specialist fits. This native-first rule does not apply to routine
+implementation volume.
 
 External quality lanes are Grok and GPT-5.6 Sol. GPT-5.6 Luna at extra-high
-reasoning and Muse Spark 1.3 are explicit cheap-volume choices, not silent
-defaults. OpenCode is a portable lane whose provider and model must be pinned.
+reasoning and Muse Spark 1.3 are cheap-volume choices. OpenCode is a portable
+lane whose provider and model must be pinned. Prefer an already authorized,
+configured cheap lane over a quality lane when both can satisfy the spec.
 Never infer or replace the user's current main model.
 
 If the work has deterministic stages, loops, or voting, use a native workflow
 only when the current host guide says the primitive exists and the user opted
 into multi-agent work. The script may own control flow; the main still owns the
 plan, evidence, and ship decision.
+
+## Keep external work visible
+
+When the current host supports native subagents, spawn one native
+worker-controller per independent implementation unit. Give it the spec and
+the selected worker guide; instruct it to preflight, launch, monitor, and report
+the external worker without writing the implementation itself. This keeps the
+cheap worker visible in the host's subagent panel and lets native workflows own
+its lifecycle. The wrapper is control plane; the cheaper model remains the
+implementation plane.
+
+Use direct external dispatch from the main only when the host has no usable
+native child primitive. Do not claim the external model appears as a native
+agent—the visible item is its controller, and its final report must identify
+the actual provider/model that performed the implementation.
 
 ## External-provider boundary
 
@@ -85,7 +108,8 @@ the provider.
 4. Preflight the lane. A missing binary, model, authentication, or write policy
    makes the lane unavailable; never silently absorb the work in the main.
 5. Write a precise spec and partition concurrent file ownership.
-6. Dispatch in the background and keep useful main-seat work moving.
+6. Spawn a native worker-controller when supported; it dispatches in the
+   background while the main keeps useful work moving.
 7. At the barrier, inspect the actual diff and worker report. Treat missing
    evidence as unverified.
 8. Re-run acceptance in the main environment, then commit and ship from here.

--- a/modules/orchestra/skills/coordinator/references/dispatch-contract.md
+++ b/modules/orchestra/skills/coordinator/references/dispatch-contract.md
@@ -54,6 +54,12 @@ cross-unit synthesis, final verification, or git operations.
 
 ## Dispatch safely
 
+- On hosts with native subagents, the main spawns a native worker-controller
+  and the controller runs the external worker command. Tell the controller not
+  to implement the spec itself or silently fall back to its own model.
+- Require the controller to report external provider/model, process outcome,
+  log location, and the worker's complete final report. Its native UI status is
+  lifecycle evidence, not proof that the external implementation succeeded.
 - Run implementation with write access but the narrowest available sandbox.
 - Run independent work in the background and preserve the complete output in a
   log. Do not pipe the worker invocation through head or tail; that can discard

--- a/modules/orchestra/skills/coordinator/references/hosts/claude.md
+++ b/modules/orchestra/skills/coordinator/references/hosts/claude.md
@@ -7,7 +7,8 @@ Read this only when Claude Code is the current main session.
 Prefer plugin-qualified Claude agents for specialist work that needs the
 session's tools, browser, MCP servers, or plugin context. Pass the specific
 subagent type from the installed roster. Use a generic agent only when no
-specialist fits.
+specialist fits. This applies to specialist judgment, not routine bounded
+implementation, which follows Coordinator's cheaper-worker default.
 
 Claude's native Workflow tool is appropriate for deterministic staged fan-outs,
 loop-until-dry discovery, verification panels, or jobs large enough that manual
@@ -26,6 +27,11 @@ the first unfinished one; consult the workflow journal when diagnosing an empty
 result.
 
 ## External workers
+
+Wrap each selected external worker in a native Claude child so it is visible
+to the host and can participate in a Workflow. The child supervises the CLI
+lane and must not implement the ticket itself. Direct shell dispatch from the
+main is only the fallback when native child dispatch is unavailable.
 
 Load only the selected worker guide:
 

--- a/modules/orchestra/skills/coordinator/references/hosts/codex.md
+++ b/modules/orchestra/skills/coordinator/references/hosts/codex.md
@@ -3,17 +3,21 @@
 Read this only when Codex is the current main session.
 
 Prefer installed bopen specialist agents, then built-in worker or explorer
-roles as an explicit fallback. Never claim a named persona ran unless that
-adapter was actually spawned. Keep orchestration in the main task; the safe
-default depth prevents children from recursively creating an uncontrolled
-tree.
+roles, for evidence, investigation, review, testing, and tool-bound judgment.
+That preference does not override Coordinator's cheaper-worker default for
+routine implementation. Never claim a named persona ran unless that adapter
+was actually spawned. Keep orchestration in the main task; the safe default
+depth prevents children from recursively creating an uncontrolled tree.
 
 Codex has native subagent coordination but no first-class workflow script
-engine. The main sequences stages and barriers. Use native Codex agents for
-work that should stay inside the current runtime; do not launch a second Codex
-CLI merely to reproduce a native subagent.
+engine. The main sequences stages and barriers. For every external
+implementation unit, spawn a native `worker` as its controller so progress is
+visible in the subagent panel. Tell that controller to run the selected cheaper
+worker guide, monitor it, and return its report—not to write the implementation
+with its own model. Use native specialists directly for judgment that should
+stay inside the current runtime.
 
-External implementation is optional. Read only the chosen guide:
+Read only the chosen implementation-worker guide:
 
 - [Grok CLI](../workers/grok.md)
 - [Muse Code](../workers/muse.md)

--- a/modules/orchestra/skills/coordinator/references/hosts/grok.md
+++ b/modules/orchestra/skills/coordinator/references/hosts/grok.md
@@ -4,9 +4,11 @@ Read this only when Grok Build is the current main session.
 
 ## Native agents
 
-Prefer roster agents on grok-4.6. Pass the named agent type; installed bOpen
-aliases may also resolve. Do not dispatch grok-4.5. Native agent model fields
-accept Grok-native slugs, not arbitrary custom model ids.
+Prefer roster agents on grok-4.6 for evidence, review, testing, and specialist
+judgment. Routine bounded implementation follows Coordinator's cheaper-worker
+default. Pass the named agent type; installed bOpen aliases may also resolve.
+Do not dispatch grok-4.5. Native agent model fields accept Grok-native slugs,
+not arbitrary custom model ids.
 
 ## Native workflows
 
@@ -26,6 +28,11 @@ grok --single -m gpt-5.6-sol in a grok-4.6 supervisor after confirming the
 quoted model entry. An unquoted dotted TOML key creates the wrong nested id.
 
 ## External workers
+
+Wrap each selected external worker in a native Grok agent so it is visible to
+the host and can participate in a workflow. The native controller supervises
+the CLI lane and must not implement the ticket itself. Direct shell dispatch
+from the main is only the fallback when native agent dispatch is unavailable.
 
 Load only the chosen guide:
 

--- a/modules/orchestra/skills/coordinator/references/hosts/opencode.md
+++ b/modules/orchestra/skills/coordinator/references/hosts/opencode.md
@@ -3,17 +3,22 @@
 Read this only when OpenCode is the current main session.
 
 Detect the host from OPENCODE=1 or OPENCODE_PID. Prefer native OpenCode agents
-from .opencode/agent/, .opencode/agents/, or opencode.json. Skills may be
-discovered from native locations and .claude/skills/.
+from .opencode/agent/, .opencode/agents/, or opencode.json for specialist
+judgment and context-bound work. For routine bounded implementation, follow
+Coordinator's cheaper-worker default and pin the selected provider/model.
+Skills may be discovered from native locations and .claude/skills/.
 
 The --agent option selects a primary or all-mode agent. It does not directly
 start an agent declared with mode: subagent. A headless primary session can
 invoke a child with an @mention; verify a child marker in the captured output
 before claiming delegation.
 
-OpenCode has no native multi-stage workflow engine. The main sequences
-opencode run calls, owns barriers, and applies the shared dispatch contract.
-Hooks are plugin event handlers rather than a portable hooks file.
+OpenCode has no native multi-stage workflow engine. The main sequences barriers
+and applies the shared dispatch contract. When OpenCode can invoke a real child
+with an `@mention`, use that child as the visible controller for an external
+worker; require child-marker evidence. The controller supervises the selected
+CLI lane and must not implement the ticket itself. Hooks are plugin event
+handlers rather than a portable hooks file.
 
 For an OpenCode worker, read [the OpenCode worker guide](../workers/opencode.md).
 For an external shell-out, read only the chosen guide:

--- a/modules/orchestra/skills/coordinator/references/workers/codex.md
+++ b/modules/orchestra/skills/coordinator/references/workers/codex.md
@@ -2,14 +2,15 @@
 
 Read this only when a separate Codex CLI process is the selected worker.
 Normally this is an external lane from Claude, Grok, or OpenCode. From a Codex
-main, prefer native agents unless isolation or the user explicitly requires a
-separate process.
+main, use native agents for specialist evidence and review; select a separate
+Codex process when it is the chosen cheaper or isolated implementation lane.
 
 ## Choose the model
 
 - GPT-5.6 Sol is the quality Codex worker.
 - GPT-5.6 Luna at extra-high reasoning is the cheap, unlimited-feeling volume
-  lane. It is not the default and must not silently replace Sol or Grok.
+  lane. Prefer it for routine implementation when it meets the acceptance
+  criteria, but never replace a lane the user explicitly selected.
 
 Both send the prompt, spec, and selected repository content to OpenAI. Apply
 the Coordinator disclosure rule before first use.

--- a/modules/orchestra/skills/coordinator/references/workers/muse.md
+++ b/modules/orchestra/skills/coordinator/references/workers/muse.md
@@ -4,8 +4,8 @@ Read this only when Muse Spark 1.3 is the selected external worker. A dispatch
 can send the prompt, spec, and selected repository content to Meta; apply the
 Coordinator disclosure rule before first use.
 
-Muse is a cheap-volume option, not the quality default. Pin Muse Spark 1.3
-because the CLI default may differ.
+Muse is a cheap implementation-volume lane, not a judgment or review lane. Pin
+Muse Spark 1.3 because the CLI default may differ.
 
 ## Preflight
 

--- a/modules/orchestra/skills/coordinator/references/workers/opencode.md
+++ b/modules/orchestra/skills/coordinator/references/workers/opencode.md
@@ -15,6 +15,10 @@ Pin the full provider/model id. A previously tested id is evidence for that
 environment, not a permanent universal id. There is no opencode exec command;
 the headless entrypoint is opencode run.
 
+When preflight lists `opencode/muse-spark-1.3-contributor-free`, it is a known
+cheap implementation choice. Pin that exact id for the run; do not assume it
+exists in another environment.
+
 ## Dispatch
 
 Use a unique prompt file for every parallel run:

--- a/modules/orchestra/skills/orchestrator/SKILL.md
+++ b/modules/orchestra/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrator
-version: 0.0.9
-description: Coordinate implementation workers, native specialists, and an optional independent advisor while the current session keeps planning, review, verification, and git ownership. Use for cross-model orchestration, worker-plus-advisor workflows, or staged multi-agent delivery.
+version: 0.0.10
+description: Coordinate cheaper implementation workers, native specialists, and an optional independent advisor while the current session keeps planning, review, verification, and git ownership. Use for cost-aware cross-model orchestration, worker-plus-advisor workflows, or staged multi-agent delivery.
 ---
 
 # Orchestrator
@@ -13,9 +13,24 @@ it.
 ```text
 current main session
 ├── native specialists: evidence, review, testing, domain expertise
-├── implementation workers: bounded code volume
+├── native worker-controllers: visible supervision in the host UI/workflow
+│   └── cheaper implementation workers: bounded code volume
 └── optional advisor: read-only opinion at a commitment boundary
 ```
+
+Invoking Orchestrator is a routing decision: spend the main model on judgment
+and send bounded implementation to an authorized, available cheaper worker.
+Do not wait for the user to repeat "cheap workers" or "model arbitrage."
+Native specialists remain preferred for evidence, investigation, review,
+testing, and tool- or domain-bound judgment; their availability is not a reason
+to keep routine implementation on the premium lane.
+
+When the host supports native subagents, wrap each external implementation
+worker in a native worker-controller. The controller launches and monitors the
+selected cheaper lane, returns its complete report, and makes the job visible
+to the host UI and native workflows. It does not implement the ticket itself.
+Dispatch the external process directly from the main only when the host lacks a
+usable native child primitive.
 
 ## Compose, do not duplicate
 
@@ -44,8 +59,9 @@ return evidence; they do not inherit those decisions.
 
 1. Orient in the main: inspect instructions, repository state, and the premise
    behind the task.
-2. Select the smallest useful topology. Avoid an advisor or a fan-out when one
-   bounded worker is enough.
+2. Select the smallest useful topology and the cheapest authorized capable
+   implementation lane. Avoid an advisor or a fan-out when one bounded worker
+   is enough.
 3. Load only the selected Coordinator host and worker references. Preflight each
    lane and disclose external data sharing before use.
 4. Gather specialist evidence with bounded, self-contained prompts. Require a
@@ -55,7 +71,8 @@ return evidence; they do not inherit those decisions.
 6. Write worker specs in the main. Partition ownership or isolate worktrees,
    pin shared interfaces, name exact acceptance commands, and forbid unrelated
    files.
-7. Dispatch independent work in parallel, then stop at a barrier before
+7. Spawn visible native worker-controllers for independent units; each
+   controller dispatches its selected cheaper worker. Stop at a barrier before
    synthesis or git operations.
 8. Review every diff, reconcile disagreements with direct evidence, re-run
    acceptance in the main environment, and ship from the main.

--- a/modules/orchestra/skills/orchestrator/agents/openai.yaml
+++ b/modules/orchestra/skills/orchestrator/agents/openai.yaml
@@ -1,7 +1,4 @@
 interface:
   display_name: "Orchestrator"
-  short_description: "Coordinate native agents, Grok workers, and Fable advice"
-  default_prompt: >-
-    Use $core:orchestrator to keep the current main agent in control
-    while routing specialist work, bounded implementation, and independent
-    advice.
+  short_description: "Wrap cheaper workers in visible native controllers"
+  default_prompt: "Use $orchestra:orchestrator to keep the current main agent in control, wrap cheaper implementation workers in visible native controllers, use native specialists for evidence and review, and add independent advice only when needed."


### PR DESCRIPTION
## Problem

The progressive-disclosure rewrite left native-specialist guidance strong enough to absorb routine implementation. Agents could follow Orchestra yet keep code-writing on premium native lanes. Direct external CLI launches also stayed invisible in native subagent panels and workflows.

## Change

- Make the cheapest authorized capable worker the default for bounded implementation.
- Keep native specialists focused on evidence, investigation, review, testing, and domain judgment.
- Wrap each external worker in a native worker-controller when the host supports native children.
- Keep shared topology and controller rules central while leaving Codex, Claude, Grok, OpenCode, and worker mechanics in progressively loaded references.
- Document the discovered OpenCode Muse Spark free implementation lane without assuming it exists everywhere.
- Patch Orchestra to 0.1.20.

## Verification

- `python3 scripts/check-plugin-manifests.py`
- `python3 scripts/check-docs.py`
- `scripts/test-isolated-plugin-install.sh`
- Independent blind routing evaluation selected three native Codex controllers, each wrapping the pinned OpenCode/Muse worker, with the main retaining review and git.
- Ponytail simplicity review passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791118691&installation_model_id=435537&pr_number=43&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F43&signature=baaaad807d3297acb09d49ac6c80518a8dfc038590d6c1452b60814aedf705d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->