### PR TITLE
Mark Codex agent adapters as generated [OPL-4436]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+codex/agents/*.toml linguist-generated=true
+codex/agents/manifest.json linguist-generated=true


### PR DESCRIPTION
## Problem

Codex requires self-contained TOML agent files, so the generated adapters repeat their canonical Markdown instructions. GitHub currently presents that mechanical copy like hand-authored source, which makes reviews noisy and makes the repository look as though it has two editable prompt sources.

## Change

Mark `codex/agents/*.toml` and its generated manifest with GitHub’s standard `linguist-generated=true` attribute.

The Markdown agents remain canonical. The generator still creates the installable TOML files and its existing check still prevents drift.

## Verification

- Git reports both adapter paths as generated
- all 30 generated Codex agents match their Markdown sources
- no runtime or installer behavior changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791125440&installation_model_id=435537&pr_number=47&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F47&signature=6bff8fdb2238c69758878bd2d01d0e90d4044ca23f9e91c2438e96dfd18c4da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->