### PR TITLE
Reconcile Orchestra skills around one dispatch contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Changed
+
+- Orchestra entry skills now compose one shared dispatch contract instead of
+  repeating host and worker manuals. Broken worker command continuations were
+  repaired. Visual Coordinator now treats OpenCode as a distinct host and
+  lane, emits native controller versus actual provider plus disclosure/context
+  boundaries, discovers Codex and OpenCode roster agents, and keeps BitPlan
+  delivery policy in a narrow reusable reference. Deterministic contract checks
+  guard these invariants. orchestra 0.1.22.
+
 ## [1.1.159] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -805,7 +805,9 @@ does not pin or rename it. The supporting skills divide responsibilities:
   harness-specific behavior to Coordinator's on-demand references.
 - `visual-coordinator` draws an editable graph of the job (nodes, labeled
   edges, reject-back gates) before it runs. Staffing, isolation,
-  concurrency, refusals, and the paste-back spec live on that canvas.
+  concurrency, native controller versus external provider, disclosure/context
+  boundaries, refusals, and the paste-back spec live on that canvas. OpenCode
+  is a distinct caller-sequenced lane and never falls through to Grok.
   On Grok it translates to a Rhai workflow, not a vague `/workflow` brief.
   `/create-workflow` is a Grok-bundled authoring skill
   (`~/.grok/bundled/skills/create-workflow/SKILL.md`). It is not part of

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/agents/agent-builder.md
+++ b/modules/orchestra/agents/agent-builder.md
@@ -33,15 +33,9 @@ skills:
   - orchestra:software-factory
   - review:free-roam-testing
 icon: https://bopen.ai/images/agents/satchmo.png
-version: 1.7.15
+version: 1.7.16
 model: opus
-description: >-
-  Agent architecture specialist. Use this agent when the user asks to "design an agent", "wire
-  up tool-calling", "add memory to my agent", "set up agent routing", "implement delegated
-  signup", "support auth.md", or "integrate ID-JAG". Covers evals, resilient chat UIs, and
-  delegated agent auth. Not for deploying a built agent to hosting or wiring its cron and
-  sandbox (use devops), authoring individual skills or commands (use prompt-engineer), or
-  auditing skill accuracy (use trainer).
+description: 'Agent architecture specialist. Use this agent when the user asks to "design an agent", "wire up tool-calling", "add memory to my agent", "set up agent routing", "implement delegated signup", "support auth.md", or "integrate ID-JAG". Covers evals, resilient chat UIs, and delegated agent auth. Not for deploying a built agent to hosting or wiring its cron and sandbox (use devops), authoring individual skills or commands (use prompt-engineer), or auditing skill accuracy (use trainer).'
 tools: Read, Write, Edit, WebFetch, Bash, Grep, Glob, TaskCreate, TaskUpdate, TaskGet, TaskList, Skill
 color: purple
 ---

--- a/modules/orchestra/scripts/test-contracts.py
+++ b/modules/orchestra/scripts/test-contracts.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Deterministic contract checks for the Orchestra skill family."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def require(text: str, needle: str, source: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{source}: missing {needle!r}")
+
+
+def main() -> None:
+    dispatchers = {
+        "orchestrator": "skills/orchestrator/SKILL.md",
+        "wave-coordinator": "skills/wave-coordinator/SKILL.md",
+        "software-factory": "skills/software-factory/SKILL.md",
+        "deploy-agent-team": "skills/deploy-agent-team/SKILL.md",
+        "visual-coordinator": "skills/visual-coordinator/SKILL.md",
+    }
+    for name, relative in dispatchers.items():
+        text = read(relative)
+        require(text, "coordinator", relative)
+        require(text, "dispatch contract", relative)
+        require(text, "provider", relative)
+        require(text, "controller", relative)
+        if len(text.splitlines()) > 275:
+            raise AssertionError(f"{name}: entrypoint is no longer thin")
+
+    advisor = read("skills/advisor/SKILL.md")
+    require(advisor, "references/channels.md", "advisor")
+    require(advisor, "dispatch contract", "advisor")
+
+    workers = list((SKILLS / "coordinator" / "references" / "workers").glob("*.md"))
+    for worker in workers:
+        text = worker.read_text(encoding="utf-8")
+        if "+      " in text:
+            raise AssertionError(f"{worker}: malformed command continuation")
+
+    canvas = read("skills/visual-coordinator/examples/graph-builder.html")
+    for needle in (
+        'if(HARNESS==="opencode") return "opencode"',
+        '["grok","claude","codex","opencode"]',
+        'if(n.lane==="opencode") return \'opencode run',
+        "function shQuote(value)",
+        'if(!n.model)',
+        "controller:n.controller||null",
+        "provider:n.provider||null",
+        "disclosure:n.disclosure||null",
+        "context:n.context||null",
+        'if(HARNESS==="opencode") lines.push',
+    ):
+        require(canvas, needle, "visual canvas")
+
+    grok_fallback = canvas.index('return "grok";')
+    opencode_branch = canvas.index('if(HARNESS==="opencode") return "opencode"')
+    if opencode_branch > grok_fallback:
+        raise AssertionError("OpenCode host falls through to Grok")
+    if 'modelsFor(hostLane())[0]||"grok-4.6"' in canvas:
+        raise AssertionError("non-Grok hosts can inherit a Grok default model")
+    if 'modelsFor(native)[0]||"grok-4.6"' in canvas:
+        raise AssertionError("seed graph can give a non-Grok host a Grok model")
+
+    emitted = read("skills/visual-coordinator/references/emitted-spec-format.md")
+    for field in ("controller", "provider", "disclosure", "context"):
+        require(emitted, field, "emitted spec")
+    require(emitted, "**OpenCode**", "emitted spec")
+
+    detector = read("skills/visual-coordinator/scripts/detect-harness.sh")
+    require(detector, 'add_flat_agents("codex"', "harness detector")
+    require(detector, 'add_flat_agents("opencode"', "harness detector")
+
+    print("orchestra contract checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/orchestra/skills/advisor/SKILL.md
+++ b/modules/orchestra/skills/advisor/SKILL.md
@@ -1,302 +1,75 @@
 ---
 name: advisor
-version: 0.0.6
-description: >-
-  Get an independent read-only second opinion at a commitment boundary, before substantive work
-  on a hard task, when stuck or changing approach, or at a final review gate. Use for "consult
-  the advisor", "get a second opinion", "ask codex", "ask Fable", "ask opencode", or "ask a bigger model". The
-  advisor returns guidance; the main session keeps execution and decision ownership.
+version: 0.0.7
+description: Get an independent read-only second opinion at a real commitment boundary. Use when the user asks for an advisor, second opinion, Fable, Codex advice, OpenCode advice, or a stronger/context-clean review before a consequential decision.
 ---
 
 # Advisor
 
-The main session borrows independent judgment at the few moments that determine
-whether the next hour of work is wasted. The advisor may be stronger, simply
-different, or context-clean. It never types the implementation; it advises.
+Borrow independent judgment without transferring execution ownership. The
+advisor answers one decision question; the main retains the plan, evidence,
+implementation, verification, and final choice.
 
-**You ARE the main executor and decision owner.** The advisor is consulted,
-never delegated implementation. If another model should write bounded code,
-that is the `coordinator` worker pattern. Use `orchestrator` when the current
-main combines specialist agents, external workers, and an advisor.
+Use [Coordinator](../coordinator/SKILL.md) when another model should implement.
+Use [Orchestrator](../orchestrator/SKILL.md) when one plan combines advisors,
+specialists, and implementation workers.
 
-When one advisor's verdict is not enough, a native workflow can run an
-adversarial panel on hosts that support it. Load only the current host guide:
-[Claude Code](../coordinator/references/hosts/claude.md) or
-[Grok Build](../coordinator/references/hosts/grok.md). A single well-packaged
-consult remains the default; panels are for the highest-stakes calls.
+## Load only the selected channel
 
-The advisor's value is only partly the stronger model: a consult also
-arrives **context-clean**, free of this session's accumulated assumptions.
-That's why a consult can pay even between equal tiers — and why every
-consult package must stand alone.
+Read [the channel guide](references/channels.md), then load only the applicable
+current-host or advisor section. For an external CLI consult, also apply the
+provider, disclosure, context-minimization, log, and evidence rules in
+[the dispatch contract](../coordinator/references/dispatch-contract.md).
 
-## Choosing the Advisor Channel
+Advice remains read-only. A prompt saying “do not edit” is not a permission
+boundary; configure the selected agent or CLI so edits and shell execution are
+denied where supported.
 
-Five channels. Detect the current host and what exists before picking; never
-assume.
+## Consult at a decision boundary
 
-| Channel | How it works | Prefer when |
-|---------|-------------|-------------|
-| **codex as advisor** | Dispatch a read-only consult to codex (plugin or CLI) | A codex quota exists — subscription capacity is usually the cheapest premium intelligence available |
-| **Native advisor tool** | Claude Code's built-in advisor (`/advisor`, `advisorModel` setting, `--advisor` flag): the executor consults a stronger Claude model mid-turn, server-side | The advisor should be a Claude model and the account has capacity for it |
-| **Premium Claude subagent** | Spawn a read-only `Agent` (Read/Grep/Glob only) pinned to a stronger Claude model; it inspects the repo fresh and returns a verdict | The advisor should be Claude AND the question needs repo inspection the transcript doesn't carry |
-| **Fable CLI from Codex** | Run a clean, read-only Claude Code print session using the configurable `fable` model-family alias | The main is Codex and an independent Claude opinion is valuable, especially for Claude-specific work |
-| **opencode as advisor** | Dispatch a read-only consult via `opencode run --model <provider/model>` | The advisor should be a cheap or independent provider (e.g. Muse Spark 1.3, Luna) reachable through OpenCode, or the main is OpenCode and the consult should stay in-harness |
+Useful boundaries include:
 
-Passive detection depends on the host:
+- architecture before expensive implementation;
+- a change of approach after repeated failure;
+- security, compatibility, or migration decisions with irreversible effects;
+- a final adversarial review before shipping a high-risk change; and
+- a disputed conclusion where a context-clean perspective adds information.
 
-1. On Codex, check `command -v claude`, `claude --version`, and
-   `claude auth status`. The Fable lane is unavailable if CLI authentication
-   is unavailable; do not silently substitute another vendor.
-2. On Claude, check `command -v codex` and whether `codex:*` plugin commands
-   are available.
-3. Is `advisorModel` set in `~/.claude/settings.json` or the project's
-   settings? (Slash commands are user-only — don't try to run `/advisor`.)
-   If it's absent and the session wasn't launched with `--advisor`, treat
-   the native channel as unconfigured and suggest the user run `/advisor`
-   to enable it. `CLAUDE_CODE_DISABLE_ADVISOR_TOOL=1` in the environment
-   means the native channel is off regardless.
-4. The premium-subagent channel needs no install — but confirm the intended
-   stronger model is actually available to the account (see the
-   silent-downgrade footgun below); an unavailable pin degrades to the
-   session model without erroring.
-5. No channel available at all? Don't silently proceed unadvised — offer to
-   enable one (the codex install/auth steps live in the coordinator skill's
-   "Enabling a lane" section; OpenCode installs via `npm i -g opencode` plus
-   `opencode auth login` or an `opencode.json` provider block).
-6. Present the finding and recommendation to the user before first use —
-   "codex is installed; recommend it as advisor" or "advisorModel is already
-   set to X; using the native tool" or "Claude CLI is authenticated; recommend
-   the Fable lane" or "opencode is installed with provider Y; recommend the
-   opencode lane" — and let them override. When multiple channels exist and
-   the user has not expressed a preference, ask once, then keep the answer for
-   the session.
-7. On an OpenCode main (`OPENCODE=1` / `OPENCODE_PID`), the opencode channel is
-   the in-harness default; external CLIs (`codex exec`, `claude --print`) are
-   shell-out consults with the same advice contract.
+Skip the consult when the answer is mechanically verifiable, the change is
+small and reversible, or the consult would merely restate existing evidence.
 
-From a Claude main, avoid launching another `claude -p` process unless the user
-asks; the native advisor or a native subagent is cleaner. The deliberate
-exception is the cross-host Fable channel from a Codex main. Its preflight must
-report which authentication path will be used because a fresh CLI invocation
-can draw from subscription capacity or bill an API key.
+## Package one self-contained question
 
-### Native advisor notes
+Provide:
 
-- The advisor sees the full transcript but runs **toolless** — it cannot read
-  files or run commands. Put the evidence in the conversation (paste the
-  failing output, the relevant snippet) *before* consulting, or the advisor
-  advises blind.
-- The advisor must be a Claude model at least as capable as the executor;
-  invalid pairings are rejected outright.
-- There is no setting to force or cap consult frequency — steer it with
-  instructions ("consult the advisor before you continue") and the timing
-  rules below.
-- Advisor usage is billed/metered at the advisor model's own rates and counts
-  against plan limits — a consult is never free. Budget accordingly.
+1. the exact decision to make;
+2. relevant evidence, code locations, and constraints;
+3. options already considered and why they are uncertain;
+4. the required verdict shape; and
+5. explicit permission boundaries.
 
-### Premium-subagent notes
+Require the response to contain:
 
-- Pin the model on the `Agent` call and keep the toolset read-only — the
-  advisor advises; it must not edit.
-- **Silent-downgrade footgun:** when a pinned Claude model isn't available
-  to the account, the subagent silently falls back to the session's model —
-  the "advisor" becomes the executor consulting itself, and nothing errors.
-  Require the advisor to state which model it is running as the first line
-  of its reply; treat a session-tier answer as no consult and switch
-  channels.
-- It does not see this conversation — package the consult fully (see below).
-  Like codex, it can read the repo, which the native advisor cannot.
-
-### Fable CLI from a Codex main
-
-Use this channel when the current main is Codex and an independent Claude
-opinion is useful. It is especially valuable for reviewing Claude agents,
-hooks, plugin behavior, or prompts where a Claude-native perspective reduces
-guesswork.
-
-Prepare the complete consult in a file. Feed it over stdin so shell quoting,
-prompt length, and repository text cannot become command interpolation:
-
-```bash
-ADVISOR_MODEL="${BOPEN_ADVISOR_MODEL:-fable}"
-PROMPT_FILE="/absolute/path/to/prepared-advisor-consult.md"
-
-COMM_FILE="${HOME}/.claude/communication.md"
-if [ ! -f "$COMM_FILE" ]; then
-  echo "missing $COMM_FILE — Fable has no communication contract" >&2
-  exit 1
-fi
-
-env -u ANTHROPIC_API_KEY claude \
-  --print \
-  --safe-mode \
-  --append-system-prompt-file "$COMM_FILE" \
-  --model "$ADVISOR_MODEL" \
-  --effort high \
-  --permission-mode plan \
-  --tools "Read,Grep,Glob" \
-  --no-session-persistence \
-  < "$PROMPT_FILE"
+```text
+VERDICT: <one sentence>
+CONFIDENCE: <high|medium|low> — <why>
+RISKS: <ranked list>
+EVIDENCE: <specific facts or file references>
+RECOMMENDED NEXT STEP: <one bounded action>
+UNKNOWN: <what could change the verdict>
 ```
 
-- `fable` is a stable model-family alias chosen for this advisor lane, not a
-  claim about a permanently latest version. Set `BOPEN_ADVISOR_MODEL` when the
-  user chooses another available Claude model.
-- `--safe-mode` keeps personal plugins, hooks, memory, and project prompt
-  customizations out of the second opinion. This preserves context independence.
-  It also drops the STE output style, so this lane must append
-  `~/.claude/communication.md` into the system prompt. Do not skip that flag.
-  If the file is missing, fail. Do not run Fable unsteered.
-- `--permission-mode plan` plus `Read,Grep,Glob` makes the lane repository-aware
-  but unable to edit or run shell commands. For a context-only consult, pass an
-  empty tool list instead.
-- `--no-session-persistence` prevents the consult from entering normal Claude
-  session history. Remove it only when the user explicitly wants a resumable
-  advisory thread.
-- `env -u ANTHROPIC_API_KEY` deliberately prefers the signed-in Claude Code
-  subscription rather than an ambient API key. If the user explicitly wants
-  API billing, omit that prefix and disclose the change.
+For a pinned model or named advisor, require it to identify itself. Treat a
+silent downgrade or missing child marker as no consult.
 
-This is an external data boundary. The consult file and any repository files
-the read tools inspect can be sent to Anthropic. Before the first Fable consult,
-say what will be shared and obtain approval unless the user already explicitly
-authorized that lane for the task. Exclude secrets, credentials, and unrelated
-proprietary content.
+## Reconcile, do not obey
 
-If `claude auth status` fails, the selected model is unavailable, or the CLI
-reports a billing/authentication mismatch, stop and report the lane as
-unavailable. Do not silently replace Fable with a different advisor.
+Compare the verdict with direct evidence and current constraints. Explain any
+disagreement. Advice never becomes an edit instruction by itself, and the
+advisor never commits, pushes, merges, or approves on the user's behalf.
 
-### codex-as-advisor notes
+## Final report
 
-- **Read-only is correct here.** Never add write flags to a consult — the
-  advisor advises; it must not edit. Bare `codex exec` is read-only by
-  default, which is right for once. The plugin is the opposite: it defaults
-  tasks to a write-capable run unless the request reads as
-  review/diagnosis/research-only — so when consulting through the plugin,
-  phrase the dispatch explicitly as advisory ("advisory only, no edits") so
-  it stays read-only.
-- Unlike the native advisor, codex **can read the repo** (read-only). Prefer
-  it for questions that require inspecting code the conversation hasn't
-  seen; prefer the native channel for questions answerable from the
-  transcript alone.
-- With the plugin installed, consults can resume a thread (`--resume`) — an
-  advisory thread that keeps context across consults is markedly better for
-  follow-ups than a cold start each time.
-- Demand structure or risk silence — an uninstructed codex run can return
-  nothing. Use the advice contract below in every consult prompt.
-
-### opencode-as-advisor notes
-
-- **Read-only is correct here.** The advisor advises; it must not edit.
-  Use an agent whose configuration denies edits and shell execution; a prompt
-  saying "no edits" is not a permission boundary. Invoke a `mode: subagent`
-  advisor through `@name`, or use `--agent <name>` only when that name is a
-  read-only primary/all-mode agent. Keep the advice contract below in every
-  consult prompt — same silence risk as codex.
-- There is no `opencode exec`. The consult entrypoint is `opencode run`:
-
-```bash
-ADVISOR_MODEL="<provider>/<model>"   # e.g. muse-spark/muse-spark-1.3; pin explicitly
-PROMPT_FILE="/absolute/path/to/prepared-advisor-consult.md"
-
-opencode run --model "$ADVISOR_MODEL" --dir <repo> \
-  "@<read-only-subagent> $(cat "$PROMPT_FILE")"
-```
-
-  Attach evidence with `-f/--file`, reuse a running server with
-  `--attach http://localhost:4096` to skip MCP cold-boot, and use
-  `--format json` when scripting the verdict out.
-- Capture the run and verify the configured advisor's child marker. A primary
-  `build` line alone does not prove the read-only child ran. OpenCode 1.18.20
-  falls back to the default primary agent when `--agent` names a subagent.
-- Preflight `command -v opencode` plus `opencode models <provider>` for the
-  pinned id. Custom providers (Muse Spark, Luna) live as `provider:{}` blocks
-  in `opencode.json` — confirm the block exists so the data destination is
-  known before the first consult.
-- This is an external data boundary. The consult file and any repository files
-  the run inspects can be sent to the pinned provider. Disclose and obtain
-  approval before the first consult, excluding secrets and unrelated content.
-- Resume with `-c/--continue` or `-s <session-id> --fork` for follow-up
-  consults on one thread rather than cold starts.
-
-### The advice contract (all channels)
-
-End every consult prompt with (verbatim or close):
-
-> Give a verdict, not a survey: "do X, not Y, because Z" plus the single
-> risk that decides it. If the plan is sound, say so in one line — do not
-> manufacture objections to justify the consult. If missing information
-> would change the answer, name it precisely and say what each answer would
-> imply. Keep it under 200 words unless the architecture genuinely demands
-> more.
-
-## When to Consult
-
-Consults happen at **commitment boundaries** — the decisions that determine
-whether the next hour of work is wasted: an architecture choice, a data
-migration, an API shape, a refactor strategy.
-
-Consult **before substantive work, not after**. Orientation — finding files,
-reading code, reproducing the bug — is not substantive work; do that first so
-the consult is informed. Writing, editing, and committing to an
-interpretation are substantive.
-
-- **Before the first state-changing action** on a hard or ambiguous task:
-  plan sketched, evidence gathered, then one consult to pressure-test the
-  approach before any file changes.
-- **When believing the task is complete** — one consult as a review gate.
-  Make the deliverable durable *first* (write the file, save the result): a
-  consult takes time, and a durable result survives an interrupted session
-  where an unwritten one doesn't.
-- **When the same problem has resisted two distinct attempts** — a third
-  attempt without new judgment is usually the first attempt again. Also when
-  stuck more generally: errors recurring, approach not converging, results
-  that don't fit the mental model.
-- **Before changing approach** — the consult is cheaper than the rewrite.
-
-Do NOT consult for mechanical steps, trivially verifiable facts, or anything
-a test run answers faster. Consults are metered; a session that consults on
-every turn has inverted the economics — and one that never consults on a
-hard task has wasted the safety net. A few consults per task, each at a real
-decision point, is the shape to aim for.
-
-## Packaging a Consult (external and subagent channels)
-
-The advisor only knows what the consult carries. Include:
-
-1. **Goal** — what the task is, one paragraph.
-2. **Constraints** — what must not change, conventions in force.
-3. **State** — what has been tried, what happened, current hypothesis.
-4. **Evidence** — the failing output, the relevant snippet, or file paths
-   for codex to read.
-5. **The question** — one specific decision to advise on, not "thoughts?".
-6. The advice contract from above.
-
-## Weighing the Advice
-
-- **Act on the verdict or surface the disagreement — never silently ignore
-  it.** Give the advice serious weight: the advisor is the stronger model,
-  and it was consulted for a reason.
-- If a recommended step **fails empirically**, or primary evidence
-  contradicts a specific claim (the file says X, the advisor assumed Y),
-  adapt — but don't silently switch. Surface the conflict in one reconcile
-  consult: "I found X, you suggest Y — which constraint breaks the tie?" The
-  advisor may have underweighted the evidence; a reconcile consult is
-  cheaper than committing to the wrong branch.
-- A passing self-test is NOT evidence the advice is wrong — it may be
-  evidence the test doesn't check what the advice is checking.
-- Report to the user when advice was sought and materially changed course;
-  the consult trail is part of the work's reasoning.
-
-## Red Flags
-
-| Thought | Reality |
-|---------|---------|
-| "I'll just decide myself, consulting is a detour" | On a hard call, the consult is minutes; the wrong branch is hours. That's the trade this skill exists for. |
-| "I'll skip the upfront consult and just confirm at the end" | The completion review gate doesn't replace the pre-work consult; advice that only ever arrives after the code exists becomes rubber-stamping. |
-| "The advisor should just fix it" | Then it's not an advisor — that's the coordinator pattern upside down. Advice comes back; execution stays here. |
-| "My test passed, so the advice was wrong" | The test may not measure what the advice addressed. Reconcile before discarding. |
-| "I'll consult on every step to be safe" | Metered consults on mechanical steps invert the economics. Decision points only. |
-| "The external advisor returned nothing, skip the consult" | Re-send once with the advice contract attached; silence is a transport/reporting failure, not a verdict. |
+State which channel and actual provider/model ran, what context was shared,
+whether disclosure/approval was satisfied, the verdict, and how the main used
+or rejected it. Never imply an advisor ran when only a channel was configured.

--- a/modules/orchestra/skills/advisor/references/channels.md
+++ b/modules/orchestra/skills/advisor/references/channels.md
@@ -1,0 +1,86 @@
+# Advisor channels
+
+Read only the section for the selected channel. Detect availability; never
+assume a binary, subscription, provider block, or model id exists.
+
+## Selection
+
+| Need | Prefer |
+|---|---|
+| Repository-aware OpenAI opinion | read-only Codex process or plugin consult |
+| Transcript-only Claude opinion | configured native Claude advisor |
+| Repository-aware Claude opinion | read-only premium Claude child |
+| Claude-native review from a Codex main | Fable CLI |
+| In-harness or alternate-provider OpenCode opinion | read-only OpenCode agent |
+
+Ask once when multiple materially different providers are available and the
+user has not chosen. External channels cross a provider boundary: disclose the
+destination and selected context before first use.
+
+## Native Claude advisor
+
+Use only when `advisorModel` is configured or the session exposes the advisor
+tool. It sees the transcript but cannot inspect files. Put the relevant
+evidence in the conversation before consulting. Usage is metered at the
+advisor model's rate.
+
+## Premium Claude child
+
+Use a read-only child with only repository-inspection tools. Pin the intended
+stronger model and require its model identity on the first line. An unavailable
+pin may silently inherit the session model; that is not an independent consult.
+
+## Fable from Codex
+
+Preflight `claude --version`, `claude auth status`, the selected model-family
+alias, and `~/.claude/communication.md`. Put the complete consult in a file and
+feed it over stdin:
+
+```bash
+env -u ANTHROPIC_API_KEY claude \
+  --print \
+  --safe-mode \
+  --append-system-prompt-file "$HOME/.claude/communication.md" \
+  --model "${BOPEN_ADVISOR_MODEL:-fable}" \
+  --effort high \
+  --permission-mode plan \
+  --tools "Read,Grep,Glob" \
+  --no-session-persistence \
+  < /absolute/path/to/consult.md
+```
+
+This prefers the signed-in Claude Code account by removing an ambient API key.
+If the user requests API billing, disclose that change. Missing authentication,
+communication policy, or model availability makes the lane unavailable.
+
+## Codex
+
+Use a read-only `codex exec` consult or a plugin request explicitly framed as
+advisory and no-edit. Codex can inspect the repository. A resumable plugin
+thread is useful for a related follow-up; otherwise prefer a fresh context.
+Always demand the structured advice contract from the entry skill.
+
+## OpenCode
+
+OpenCode is the harness, not the provider. Inspect `opencode.json`, list the
+selected provider's models, and pin the complete `provider/model` id. Configure
+a named agent whose permissions deny edits and shell execution.
+
+`--agent` selects primary/all-mode agents. Invoke a `mode: subagent` advisor by
+mentioning it from a primary session and verify its child marker:
+
+```bash
+opencode run --model "<provider>/<model>" --dir <repo> \
+  "@<read-only-subagent> Review the attached consult and return the required verdict."
+```
+
+Use `-f/--file` for evidence, `--format json` for scripted results, or
+`--attach` to reuse a running server. There is no `opencode exec`. A primary
+run without the expected child marker does not prove the advisor ran.
+
+## Failure behavior
+
+Unavailable authentication, model, or permission controls make a channel
+unavailable. Do not silently replace its provider or absorb the consult into
+the main model. Preserve the question and ask the user to authorize another
+channel when independent advice still matters.

--- a/modules/orchestra/skills/claudex/SKILL.md
+++ b/modules/orchestra/skills/claudex/SKILL.md
@@ -1,11 +1,7 @@
 ---
 name: claudex
-description: >-
-  Run the Claude Code harness on GPT-5.6 Sol through a local CLIProxyAPI proxy when Anthropic
-  usage runs out, and diagnose that setup when it drifts. Use for "my Anthropic usage ran out",
-  "keep working on another model", "run Claude Code on GPT-5.6 Sol", "set up claudex", "claudex
-  isn't working", or "bill against my Codex subscription". macOS + Homebrew.
-version: 0.0.2
+description: 'Run the Claude Code harness on GPT-5.6 Sol through a local CLIProxyAPI proxy when Anthropic usage runs out, and diagnose that setup when it drifts. Use for "my Anthropic usage ran out", "keep working on another model", "run Claude Code on GPT-5.6 Sol", "set up claudex", "claudex isn''t working", or "bill against my Codex subscription". macOS + Homebrew.'
+version: 0.0.3
 user-invocable: true
 ---
 

--- a/modules/orchestra/skills/coordinator/SKILL.md
+++ b/modules/orchestra/skills/coordinator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coordinator
-version: 0.0.16
+version: 0.0.17
 description: Route bounded implementation from a capable main session to cheaper workers while keeping planning, review, verification, and git in the main seat. Use for worker dispatch, model arbitrage, parallel implementation, Sol, Luna, Muse, Grok, OpenCode, or native workflows.
 ---
 

--- a/modules/orchestra/skills/coordinator/references/dispatch-contract.md
+++ b/modules/orchestra/skills/coordinator/references/dispatch-contract.md
@@ -57,8 +57,9 @@ cross-unit synthesis, final verification, or git operations.
 - On hosts with native subagents, the main spawns a native worker-controller
   and the controller runs the external worker command. Tell the controller not
   to implement the spec itself or silently fall back to its own model.
-- Require the controller to report external provider/model, process outcome,
-  log location, and the worker's complete final report. Its native UI status is
+- Require the controller to report its native controller identity, external
+  provider/model, disclosure state, exact context shared, process outcome, log
+  location, and the worker's complete final report. Its native UI status is
   lifecycle evidence, not proof that the external implementation succeeded.
 - Run implementation with write access but the narrowest available sandbox.
 - Run independent work in the background and preserve the complete output in a

--- a/modules/orchestra/skills/coordinator/references/workers/codex.md
+++ b/modules/orchestra/skills/coordinator/references/workers/codex.md
@@ -29,11 +29,21 @@ the user approves the machine-level change.
 
 Sol:
 
-    codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-sol +      -c model_reasoning_effort="high" +      "<imperative; details in SPEC file>" +      > /tmp/dispatch-<id>.log 2>&1 &
+```bash
+codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-sol \
+  -c model_reasoning_effort="high" \
+  "<imperative; details in SPEC file>" \
+  > /tmp/dispatch-<id>.log 2>&1 &
+```
 
 Luna:
 
-    codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-luna +      -c model_reasoning_effort="xhigh" +      "<imperative; details in SPEC file>" +      > /tmp/dispatch-<id>.log 2>&1 &
+```bash
+codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-luna \
+  -c model_reasoning_effort="xhigh" \
+  "<imperative; details in SPEC file>" \
+  > /tmp/dispatch-<id>.log 2>&1 &
+```
 
 If Luna rejects xhigh, try max once and report which effort actually ran. Luna
 without extra-high or max is not this lane. Capture complete output and demand

--- a/modules/orchestra/skills/coordinator/references/workers/grok.md
+++ b/modules/orchestra/skills/coordinator/references/workers/grok.md
@@ -15,11 +15,16 @@ and offer setup rather than silently implementing in the main.
 
 Use a unique prompt file for every parallel run:
 
-    PROMPT_FILE=$(mktemp -t grok-prompt.XXXXXX)
-    grok models
-    : "${BOPEN_WORKER_MODEL:?Select an id listed by grok models}"
-    printf '%s\n' "<imperative; details in SPEC file>" > "$PROMPT_FILE"
-    grok --prompt-file "$PROMPT_FILE" -m "$BOPEN_WORKER_MODEL" +      --permission-mode acceptEdits --sandbox workspace +      --output-format plain --cwd <repo> +      > /tmp/dispatch-<id>.log 2>&1 &
+```bash
+PROMPT_FILE=$(mktemp -t grok-prompt.XXXXXX)
+grok models
+: "${BOPEN_WORKER_MODEL:?Select an id listed by grok models}"
+printf '%s\n' "<imperative; details in SPEC file>" > "$PROMPT_FILE"
+grok --prompt-file "$PROMPT_FILE" -m "$BOPEN_WORKER_MODEL" \
+  --permission-mode acceptEdits --sandbox workspace \
+  --output-format plain --cwd <repo> \
+  > /tmp/dispatch-<id>.log 2>&1 &
+```
 
 Use acceptEdits for implementation, never an unrestricted approval mode.
 Verify that the named sandbox profile actually applied: an unknown Grok

--- a/modules/orchestra/skills/coordinator/references/workers/muse.md
+++ b/modules/orchestra/skills/coordinator/references/workers/muse.md
@@ -15,9 +15,13 @@ the user's machine, then repeat preflight.
 
 ## Dispatch
 
-    PROMPT_FILE=$(mktemp -t muse-prompt.XXXXXX)
-    printf '%s\n' "<imperative; details in SPEC file>" > "$PROMPT_FILE"
-    muse exec --prompt-file "$PROMPT_FILE" --model muse-spark-1.3 +      --reasoning-effort xhigh --disable-approval --workspace <repo> +      > /tmp/dispatch-<id>.log 2>&1 &
+```bash
+PROMPT_FILE=$(mktemp -t muse-prompt.XXXXXX)
+printf '%s\n' "<imperative; details in SPEC file>" > "$PROMPT_FILE"
+muse exec --prompt-file "$PROMPT_FILE" --model muse-spark-1.3 \
+  --reasoning-effort xhigh --disable-approval --workspace <repo> \
+  > /tmp/dispatch-<id>.log 2>&1 &
+```
 
 Disable approval while retaining the OS sandbox. Never use yolo mode for a
 worker because it removes that boundary. A successful process exit is not proof

--- a/modules/orchestra/skills/coordinator/references/workers/opencode.md
+++ b/modules/orchestra/skills/coordinator/references/workers/opencode.md
@@ -23,9 +23,13 @@ exists in another environment.
 
 Use a unique prompt file for every parallel run:
 
-    PROMPT_FILE=$(mktemp -t opencode-prompt.XXXXXX)
-    printf '%s\n' "<imperative; details in SPEC file>" > "$PROMPT_FILE"
-    opencode run --model "<provider>/<model>" --dir <repo> +      "$(cat "$PROMPT_FILE")" > /tmp/dispatch-<id>.log 2>&1 &
+```bash
+PROMPT_FILE=$(mktemp -t opencode-prompt.XXXXXX)
+printf '%s\n' "<imperative; details in SPEC file>" > "$PROMPT_FILE"
+opencode run --model "<provider>/<model>" --dir <repo> \
+  "$(cat "$PROMPT_FILE")" \
+  > /tmp/dispatch-<id>.log 2>&1 &
+```
 
 Use JSON output for scripting or attach to a running server when that avoids
 repeated MCP startup. Capture the full log and demand the shared final report.
@@ -39,7 +43,10 @@ one declared with mode: subagent.
 For a real child, start a headless primary session and invoke the named child
 with an @mention:
 
-    opencode run --model "<provider>/<model>" --dir <repo> +      "@general <bounded task>"
+```bash
+opencode run --model "<provider>/<model>" --dir <repo> \
+  "@general <bounded task>"
+```
 
 A subagent without its own model inherits the parent model. Verify a child
 marker such as General Agent in the captured output before claiming delegation;

--- a/modules/orchestra/skills/deploy-agent-team/SKILL.md
+++ b/modules/orchestra/skills/deploy-agent-team/SKILL.md
@@ -1,226 +1,83 @@
 ---
 name: deploy-agent-team
-version: 1.0.6
-description: This skill should be used when the user says "deploy a team", "spin up agents to work on this", "use all our agents", "coordinate specialists", or wants to break a large task into parallel sub-tasks handled by multiple domain experts simultaneously. Orchestrates Claude Code's experimental agent team system using the full installed specialist roster.
+version: 1.0.7
+description: Coordinate a Claude Code agent team of named specialists through a shared task list and message bus. Use when the user asks to deploy a team, coordinate specialists, or run a large Claude-native parallel effort.
 disable-model-invocation: true
 ---
 
 # Deploy Agent Team
 
-Deploy a coordinated team of specialized agents from the core kit using Claude Code's agent team system. Agents work in parallel on independent tasks and communicate through a shared task list and message bus.
+Use Claude Code's experimental team system for a coordinated group of named
+specialists. This skill owns team creation, shared tasks, communication, and
+shutdown. It does not redefine worker economics or implementation safety.
+
+## Load the shared contract
+
+Before any implementation dispatch, read [Coordinator](../coordinator/SKILL.md),
+the [dispatch contract](../coordinator/references/dispatch-contract.md), and the
+[Claude host guide](../coordinator/references/hosts/claude.md). If a teammate
+controls an external cheaper worker, also load only that worker guide.
+
+The shared contract governs specs, exclusive ownership, provider disclosure,
+visible native controllers, complete reports, review, verification, and git.
+This team skill adds Claude-specific coordination around it.
 
 ## Prerequisites
 
-Agent teams require this env var to be set:
+Agent teams require `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Inspect the live
+Agent tool schema and permission settings before spawning. Prefer a narrow,
+non-interactive per-child mode when supported. Never enable unrestricted
+permissions just to suppress prompts.
 
-```bash
-CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
-```
+Read:
 
-Add to `~/.claude/settings.json`:
-```json
-{
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  }
-}
-```
+- [permissions and isolation](references/permissions-and-isolation.md) before
+  assigning write access;
+- [agent roster](references/agent-roster.md) before choosing a specialist; and
+- [spawn prompt guide](references/spawn-prompt-guide.md) before creating a
+  teammate.
 
-Without this, `TeamCreate` will fail.
+## Lifecycle
 
-## Critical: Configure Permissions Before Spawning
+1. Decompose the job into independent units and dependency edges.
+2. Write the required specs in the lead session. Pin shared interfaces and
+   exclusive file ownership.
+3. Create one team and all known tasks up front. Express ordering with task
+   dependencies rather than prose.
+4. Match each unit to a named roster specialist. Use a generic teammate only
+   when no specialist fits, and record why.
+5. Spawn self-contained teammates. They receive no conversation history.
+6. When bounded implementation belongs on an external cheap lane, make the
+   teammate a controller: it launches and monitors that lane, reports the
+   actual provider/model and full worker output, and does not implement.
+7. Monitor through the task list and direct messages. Idle between assignments
+   is normal; wake a teammate with a direct message.
+8. Stop at a barrier before reconciliation, final verification, or git.
+9. Request shutdown from every teammate, wait for acknowledgements, then
+   delete the team.
 
-Start from the lead session's permission settings and inspect the installed
-`Agent` tool schema before spawning. Current builds can accept a per-spawn
-`mode`; use a safe non-interactive mode such as `dontAsk`/`auto` with narrow
-allow rules when available. If the host does not expose that field, the teammate
-inherits the lead. Permission requests may bubble up to the lead.
+## Team-specific rules
 
-Do not launch the lead with `--dangerously-skip-permissions` merely to avoid team
-prompts. Reserve that mode for an explicitly trusted, externally sandboxed
-environment.
+- Only the lead creates the team; teammates do not create nested teams.
+- A teammate claims and completes one task at a time.
+- Every prompt contains the absolute repository path, objective, owned paths,
+  forbidden paths, relevant skills, acceptance checks, and final-report shape.
+- Use task state for status and plain text for messages.
+- Broadcast sparingly; it multiplies into one message per teammate.
+- The lead remains responsible for the combined diff and all git operations.
 
-See `references/permissions-and-isolation.md` for the permission and file-ownership
-model.
+## Failure behavior
 
-## Available Agent Roster (Abbreviated)
+- Permission prompts: narrow or pre-approve the specific required operation.
+- Off-script teammate: correct directly; shut down and replace if necessary.
+- Missing report: request the complete report before accepting the task.
+- External controller silently implements or changes provider: reject the
+  result and re-dispatch under the shared contract.
+- Team deletion failure: a teammate is still active; finish shutdown first.
 
-| Agent | subagent_type | Best for |
-|-------|--------------|----------|
-| **researcher** | `research:researcher` | Libraries, APIs, docs, competitive analysis |
-| **nextjs** | `web-dev:nextjs` | Next.js, React, Vercel, RSC, app router |
-| **native-desktop** | `creative:native-desktop` | Native SDK, Zig, WebViews, menu-bar apps, signed DMGs |
-| **designer** | `web-dev:designer` | UI, game HUDs, TV shells, directional focus, Tailwind, accessibility |
-| **agent-builder** | `orchestra:agent-builder` | AI SDK v7 agents, durable runtime selection, conditional eve evaluation |
-| **database** | `dev-ops:database` | Schema, queries, PostgreSQL, Redis, Convex |
-| **integration-expert** | `dev-ops:integration-expert` | REST APIs, webhooks, third-party services |
-| **code-auditor** | `review:code-auditor` | Security review, vulnerability scanning |
-| **tester** | `review:tester` | Unit, integration, e2e tests, CI |
-| **documentation-writer** | `research:documentation-writer` | READMEs, API docs, PRDs, guides |
-| **devops** | `dev-ops:devops` | Vercel+Railway+Bun, CI/CD, monitoring |
-| **optimizer** | `web-dev:optimizer` | Bundle analysis, Lighthouse, Core Web Vitals |
-| **architecture-reviewer** | `review:architecture-reviewer` | System design, refactoring strategy, tech debt |
-| **mobile** | `web-dev:mobile` | Expo-first React Native, Swift, Kotlin, Flutter |
-| **payments** | `dev-ops:payments` | Stripe, billing, financial transactions |
-| **marketer** | `product-skills:marketer` | CRO, SEO, copy, launch strategy |
-| **legal** | `product-skills:legal` | Privacy, compliance, ToS |
-| **mcp** | `mcp-dev:mcp` | MCP server setup, config, diagnostics |
-| **social-media-manager** | `brand-rep:social-media-manager` | Owned-account posts, calendars, mention replies |
+## Final report
 
-Full roster with per-agent skills to mention in spawn prompts: `references/agent-roster.md`
-
-## Full Team Lifecycle
-
-### Step 1: Decompose the task
-
-Before calling any tools, identify:
-- What domains are involved? (frontend, backend, testing, docs, security...)
-- Which tasks can run in parallel vs. must be sequential?
-- What are the dependencies? (schema before API, API before tests)
-
-### Step 2: Create the team
-
-```
-TeamCreate(
-  team_name: "feature-billing",
-  description: "Implement Stripe billing with UI, API, tests, and docs"
-)
-```
-
-### Step 3: Create tasks upfront
-
-Set dependencies with `addBlockedBy` where order matters:
-
-```
-TaskCreate(
-  subject: "Design billing UI components",
-  description: "Create PricingCard, BillingHistory, UpgradeModal using shadcn/ui.
-  Repo: ~/code/myapp. Tailwind v4. Output: src/components/billing/.",
-  activeForm: "Designing billing UI"
-) → id: "1"
-
-TaskCreate(
-  subject: "Implement Stripe integration",
-  description: "Set up webhooks, subscription creation, customer portal.
-  Repo: ~/code/myapp. API routes in app/api/billing/.",
-  activeForm: "Implementing Stripe integration"
-) → id: "2"
-
-TaskCreate(
-  subject: "Write billing test suite",
-  description: "Vitest tests for all billing API routes and webhook handler.
-  Repo: ~/code/myapp. Tests in __tests__/billing/.",
-  activeForm: "Writing billing tests"
-) → id: "3"
-
-TaskUpdate(taskId: "3", addBlockedBy: ["2"])  # tests wait for Stripe impl
-```
-
-### Step 4: Spawn teammates
-
-```
-Agent(
-  subagent_type: "web-dev:designer",
-  name: "designer",
-  mode: "dontAsk",
-  prompt: "..."  # see references/spawn-prompt-guide.md
-)
-```
-
-Every spawn prompt must be **self-contained** — teammates have zero conversation history. See `references/spawn-prompt-guide.md` for the full template and how to list each agent's available skills.
-
-### Step 5: Monitor and coordinate
-
-Messages from teammates arrive automatically. Check progress:
-```
-TaskList()
-```
-
-Answer a blocked teammate:
-```
-SendMessage(
-  type: "message",
-  recipient: "backend",
-  content: "Stripe webhook secret is STRIPE_WEBHOOK_SECRET in .env.local",
-  summary: "Stripe secret location"
-)
-```
-
-### Step 6: Shutdown and cleanup
-
-```
-SendMessage(type: "shutdown_request", recipient: "designer", content: "Work complete")
-SendMessage(type: "shutdown_request", recipient: "backend", content: "Work complete")
-SendMessage(type: "shutdown_request", recipient: "tester", content: "Work complete")
-
-# Wait for each shutdown_response, then:
-TeamDelete()
-```
-
-## Task Decomposition Patterns
-
-### Feature implementation
-```
-Parallel from the start:
-├── researcher: research best practices / prior art
-├── designer: UI components
-├── nextjs or integration-expert: API / server logic
-└── database: schema changes
-
-Blocked until implementation complete:
-├── tester: test suite
-└── documentation-writer: feature docs
-```
-
-### Security audit + fix
-```
-Parallel:
-├── code-auditor: full vulnerability scan (Semgrep, CodeQL)
-└── architecture-reviewer: structural/design issues
-
-Blocked until audit complete:
-├── nextjs or integration-expert: fix findings
-└── tester: regression tests
-```
-
-### Launch prep
-```
-Parallel:
-├── code-auditor: security review
-├── tester: coverage audit
-├── optimizer: Lighthouse + bundle
-├── documentation-writer: user-facing docs
-└── legal: privacy / ToS
-
-Blocked until all above complete:
-└── devops: deploy pipeline
-```
-
-## Key Rules
-
-- **Use the safest effective permission mode**: pre-approve only the operations teammates need; never default to bypass
-- **Self-contained prompts**: teammates get zero conversation history — include repo path, conventions, and full context
-- **Mention agent skills in spawn prompts** — each agent has specialized skills; tell them which to use
-- **One task at a time**: claim → complete → claim next. No parallel hoarding
-- **No JSON in messages**: use TaskUpdate for status. SendMessage is plain text only
-- **Idle is normal**: teammates go idle between tasks. Send a message to wake them
-- **No nested teams**: only the lead calls TeamCreate
-- **Shutdown before TeamDelete**: TeamDelete fails if any teammate is still active
-- **Broadcast sparingly**: each broadcast = one API call per teammate
-
-## Troubleshooting
-
-| Problem | Fix |
-|---------|-----|
-| `TeamCreate` fails | Check `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set |
-| Teammate hits permission prompts | Pre-approve the specific safe operation in the lead's settings, then retry |
-| Teammate not claiming tasks | Check `blockedBy` deps with `TaskGet` |
-| Teammate idle and unresponsive | Send a direct `SendMessage` — idle agents wake on receipt |
-| `TeamDelete` fails | Teammates still running. Send `shutdown_request` to each |
-| Teammate went off-script | Send correction via `SendMessage`. If severe, shutdown and respawn |
-
-## References
-
-- `references/permissions-and-isolation.md` — inherited permissions and safe file partitioning
-- `references/agent-roster.md` — full roster table + which skills to mention per agent in spawn prompts
-- `references/spawn-prompt-guide.md` — complete spawn prompt template with skills section
+Name the specialists and controllers that actually ran, each external
+provider/model and disclosure state, accepted and rejected work, verification
+results, and unresolved dependencies. Never claim a teammate or provider ran
+from configuration alone.

--- a/modules/orchestra/skills/software-factory/SKILL.md
+++ b/modules/orchestra/skills/software-factory/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: software-factory
-version: 0.0.10
-description: >-
-  Design or harden a software factory: an agentic loop that iterates toward a goal with a
-  verification gate, persistent state, and a stop condition. Use for "build a loop", "agentic
-  loop", "self-iterating agent", "/loop", "/goal", "Ralph loop", "maker-checker", "agentic
-  SDLC", "ADW", picking a verification gate, bounding a loop's blast radius, unintelligible
-  auto-merged PR titles, or loop process dumped into a GitHub PR body.
+version: 0.0.11
+description: 'Design or harden a software factory: an agentic loop that iterates toward a goal with a verification gate, persistent state, and a stop condition. Use for "build a loop", "agentic loop", "self-iterating agent", "/loop", "/goal", "Ralph loop", "maker-checker", "agentic SDLC", "ADW", picking a verification gate, bounding a loop''s blast radius, unintelligible auto-merged PR titles, or loop process dumped into a GitHub PR body.'
 ---
 
 # Software Factory
@@ -64,60 +59,37 @@ The dedup-vs-open-tickets step is what stops discovery from re-filing the same i
 
 At factory scale, a **router** sits above all worker types: work arrives typed (chore, bug, feature, hotfix), and the router picks the workflow and the model tier for it — a workhorse maker for volume, a state-of-the-art model only where planning or checking earns it. Speed-critical work (hotfixes) can **race**: several isolated agents attack the same fix in parallel and the first one through the gate wins. Isolation progresses with maturity — git worktrees are a great place to start and a poor place to end; sandboxes give full isolation plus a place a human can step into mid-run.
 
-On a host with a native workflow engine, staged fan-outs inside a loop pass can
-run as a deterministic workflow. Load only the current Coordinator host guide:
-`skills/coordinator/references/hosts/claude.md` or
-`skills/coordinator/references/hosts/grok.md`. On Codex and OpenCode, the
-manual protocols in `wave-coordinator` provide the equivalent barriers.
+## Compose dispatch instead of embedding it
 
-## The staged multi-model pipeline — the verified recipe
+When a factory pass dispatches implementation, read
+[Coordinator](../coordinator/SKILL.md), the shared
+[dispatch contract](../coordinator/references/dispatch-contract.md), exactly
+one current-host guide, and only the selected worker guides. Those resources
+govern cheap-lane selection, native controllers, provider disclosure, specs,
+logs, review, verification, and git. Do not copy their command manuals into a
+factory configuration.
 
-The maker/checker split above is doctrine; this is the concrete, field-verified wiring for an
-execution worker. **A headless loop that runs one monolithic session — one model playing planner,
-maker, checker, and shipper in a single context — will eventually write a wrong diagnosis into a
-ticket as fact, because its mechanical gate verifies code and nothing verifies claims.** (Field case:
-a loop asserted "rotate the credential" on a CI outage without evidence; a second single-context agent
-then flipped it to "stale, skip it" — also without evidence. Both survived because no adversarial
-reviewer ever existed. The outage was real; both written diagnoses were unverified guesses.)
+The factory adds recurrence and promotion policy:
 
-The verified shape — every lane below was live-tested headless before this section was written:
+- pin the model and provider for every agent stage;
+- keep planning, implementation, independent review, and the objective gate as
+  distinct nodes;
+- make external implementation visible under a native controller when the host
+  supports children;
+- record controller id, actual provider/model, disclosure state, and context
+  shared in the durable ledger;
+- if the checker is unavailable, stop at propose-only; and
+- let only the main/promotion worker perform reviewed git and release actions.
 
-| Stage | Model / lane | Invocation (verified) | What it guards |
-|---|---|---|---|
-| **Plan** | strongest planner (e.g. fable) | native `Workflow` `agent(..., { model: 'fable', schema })` | Premise verification BEFORE decomposition; routes each item to a lane + named roster agent |
-| **Implement** | cheap workers: external CLI (e.g. `grok -m grok-4.6 --permission-mode acceptEdits`) or named roster agents (`agentType`) | supervisor-agent pattern: a thin workflow agent writes the spec file, drives the CLI via Bash, relays the report + `git diff --stat` | Volume off the main seat; disjoint file partitions per item |
-| **Review** | independent CROSS-VENDOR checker (e.g. `codex exec -m gpt-5.6-sol --sandbox read-only`) | supervisor agent builds a review brief (diff + every claim), demands a schema verdict | The missing gate: adversarial review of the diff AND the claims; one corrective round max |
-| **Gate + ship** | main seat, model PINNED in loop config | mechanical gate unpiped, then `lint-pr.sh` if opening a PR, then git | Merge requires gate green **AND** `verdict.approved`. Auto-merged PRs also require the human-artifact linter green |
+On Claude Code or Grok Build, a native workflow engine may express deterministic
+stages. Codex and OpenCode use caller-owned sequencing and Wave Coordinator
+barriers. Runtime-specific syntax belongs in Coordinator host references.
 
-Non-negotiables learned the hard way:
-
-- **The native `Workflow` tool works inside headless `claude -p`** — verified. Commit the workflow
-  script to the repo (`scriptPath`), version it like code, and give it a `selftest` arg so CI and
-  humans can probe parse/load without spawning agents. (Runtime gotcha: the exported `meta` const is
-  not in scope in the script body; `Date.now()`/`Math.random()` are unavailable — pass timestamps in
-  via args.)
-- **Pin every model explicitly — the loop config, the workflow stages, the CLI dispatches.** A loop
-  that inherits a mutable CLI default silently runs on whatever model the maintainer's interactive
-  sessions last saved; a real loop ran weeks on a stale model this way and nobody knew.
-- **The checker reviews CLAIMS, not just diffs.** Any diagnosis, decline rationale, or "X is broken
-  because Y" that will be written to a ticket must carry evidence and pass the checker first.
-  Unverifiable ⇒ label it "unverified hypothesis" or write nothing. Claims-only tickets route through
-  the same review stage with no diff.
-- **No checker ⇒ propose-only.** Lane preflight (binary + auth + pinned-model-exists, e.g.
-  `grok models | grep`) runs every cycle; a down worker lane re-routes explicitly to roster agents,
-  and a down checker lane downgrades the cycle to open-PR-and-stop. The loop never self-approves, and
-  a lane never silently collapses into the main seat.
-- **Data boundary:** external lanes cross vendors (specs to xAI, review briefs to OpenAI). Specs and
-  briefs carry code excerpts, never secrets or env values. launchd does not source shell profiles —
-  file-based auth (codex `auth.json`, `grok login`) or an explicitly-sourced env file, checked at
-  preflight.
-- **GitHub is for humans.** Tickets hold work items; the loop ledger holds process. A loop that
-  auto-merges without a human rewrite must lint PR titles and bodies as **code**
-  (`scripts/lint-pr.sh` + CI), not as another prompt. Field case: auto-merged PRs with ticket-id
-  prefixes and checker dumps a human could not scan (Scribe, 2026-08). T3 Code discovers the
-  same contract via always-on `AGENTS.md`; T3 does not auto-merge, so prompt-only is enough
-  there. Follow `references/human-artifacts.md`. `/factory-init` copies the templates when the
-  connector list includes `gh pr create`.
+The checker reviews claims as well as diffs. A diagnosis written into a ticket
+needs evidence; otherwise label it an unverified hypothesis or omit it. Keep
+human-facing PR policy in [human artifacts](references/human-artifacts.md) and
+promotion behavior in
+[shipping and isolation](references/shipping-and-isolation.md).
 
 ### Agent runtime selection
 

--- a/modules/orchestra/skills/visual-coordinator/SKILL.md
+++ b/modules/orchestra/skills/visual-coordinator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: visual-coordinator
 description: This skill should be used when the user asks to "design the workflow visually", "show me the workflow before running it", "let me configure the agents first", "visual workflow builder", "which models for which steps", "let me pick the models", "plan this fan-out", "diagram the orchestration", or wants to review and adjust a multi-agent job — models, agents, phases, isolation — before it runs. Renders an editable graph (nodes, labeled edges, reject-back gates) the user can rewire; staffing is on the selected card. Emits a paste-back spec from the live graph. Builds on the coordinator skill; use coordinator alone when no visual review is wanted.
-version: 0.1.8
+version: 0.1.9
 ---
 
 # Visual Coordinator
@@ -90,6 +90,9 @@ Required on the page:
 - **Isolation, live-children, and cwd dials** — bounded by detector caps.
   Effort lists come from `models.<lane>_effort`. Unavailable lanes stay
   selectable and warn.
+- **External boundary fields** — every external node distinguishes its visible
+  native controller from the actual provider/model, records disclosure state,
+  and names the exact context allowed to cross the boundary.
 - **Refusal list** — impossible settings (foreign native model, over-cap
   concurrency, schema on a shell-out, missing CLI) show on the page and
   in Copy spec.
@@ -100,18 +103,10 @@ Required on the page:
 
 ### 3b. Deliver the page
 
-A file path in chat is not a page. Claude Code can host HTML as an
-Artifact. Grok Build and Codex cannot.
-
-On Claude Code, publish the canvas as an Artifact. On every other host, load
-BitPlan's canonical skill (`Skill(bitplan:bitplan)` for the plugin or
-`Skill(bitplan)` for a standalone install) and use a hosted encrypted draft
-after the user approves it. Prefer an existing BRC-100 wallet. The planned 1Sat CLI
-fallback is not application-compatible yet, so do not point BitPlan at `1sat
-serve wallet`. If no compatible wallet is available, open the local file. Only
-after the user explicitly declines the wallet paths may you offer PostPlan as
-an unencrypted hosted fallback and ask before uploading. Do not stop after
-writing `docs/*.html` without giving the user a page they can actually open.
+A file path in chat is not a page. Follow
+[the visual delivery policy](references/visual-delivery.md). It keeps BitPlan's
+external-provider and wallet rules narrow and reusable rather than mixing them
+with graph construction.
 
 ### 4. Emit the spec
 
@@ -129,7 +124,12 @@ JavaScript workflow script; Grok maps onto a Rhai workflow (bundled
 `/create-workflow`, native `agent_type` + `model`, Sol/Claude nodes as
 Grok-CLI or Claude-CLI shell-outs);
 Codex becomes an ordered series of `codex exec` dispatches the caller sequences.
-Then run it under the ordinary `coordinator` rules: specs before dispatch,
+OpenCode becomes caller-sequenced `opencode run` dispatches and `@agent`
+children; it must never fall through to Grok translation.
+Before dispatch, read [Coordinator](../coordinator/SKILL.md), its shared
+[dispatch contract](../coordinator/references/dispatch-contract.md), exactly
+one current-host guide, and only the selected worker guides. Then run it under
+those rules: specs before dispatch,
 review diffs adversarially, re-run acceptance outside the worker's sandbox, and
 keep every git operation in the main session. Smoke-check a Grok script with
 `validate_only: true` before a real run.
@@ -146,7 +146,7 @@ draws initials from `display_name` in a coloured circle.
 
 ### Reference Files
 
-- **`references/harness-capabilities.md`** — what Claude Code, Codex, and Grok
+- **`references/harness-capabilities.md`** — what Claude Code, Codex, Grok, and OpenCode
   each genuinely support: primitives, caps, isolation, resume semantics, model
   identifiers, and the claims the canvas must never make.
 - **`references/emitted-spec-format.md`** — the exact shape of the paste-back
@@ -154,6 +154,8 @@ draws initials from `display_name` in a coloured circle.
   configuration.
 - **`references/decomposition.md`** — how to choose the graph: nodes, edges,
   reject-back, barriers, sizing, isolation. Read before seeding, not after.
+- **`references/visual-delivery.md`** — Artifact, BitPlan, wallet, local-file,
+  and explicit unencrypted-fallback policy.
 
 ### Assets
 
@@ -162,10 +164,9 @@ draws initials from `display_name` in a coloured circle.
 
 ### Scripts
 
-- **`scripts/detect-harness.sh`** — reports host harness (`GROK_AGENT` for
-  Grok Build), `native_workflow`, live-child / budget caps, available lanes,
-  real model lists per lane, and the deduplicated installed agent roster
-  (Claude plugin cache plus `~/.grok/installed-plugins`).
+- **`scripts/detect-harness.sh`** — reports host harness, workflow/capacity,
+  available lanes, real model lists, and deduplicated Claude, Grok, Codex, and
+  OpenCode roster agents.
 
 ### Related Skills
 

--- a/modules/orchestra/skills/visual-coordinator/assets/canvas-runtime.js
+++ b/modules/orchestra/skills/visual-coordinator/assets/canvas-runtime.js
@@ -12,14 +12,16 @@
  *   {
  *     name, isolation, concurrency, cwd,
  *     nodes: [{ id, kind, x, y, label, detail, lane, model, effort,
- *               agentType, task, gateCmd, schema, paths, command }],
+ *               agentType, controller, provider, disclosure, context,
+ *               task, gateCmd, schema, paths, command }],
  *     edges: [{ id, from, to, label, kind: "forward"|"reject"|"memory" }]
  *   }
  * Env: {
  *   harness,
- *   models: { grok, grok_effort, claude, claude_effort, codex, codex_effort },
+ *   models: { grok, grok_effort, claude, claude_effort, codex, codex_effort,
+ *             opencode, opencode_effort },
  *   roster: [{ id, display_name, avatar? }],
- *   lanes: { grok, claude, codex }  // "available" | "unavailable"
+ *   lanes: { grok, claude, codex, opencode }  // "available" | "unavailable"
  *   caps: { live_children },
  *   cwd
  * }

--- a/modules/orchestra/skills/visual-coordinator/examples/graph-builder.html
+++ b/modules/orchestra/skills/visual-coordinator/examples/graph-builder.html
@@ -141,9 +141,10 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
   var MODELS = ENV.models || {
     grok:["grok-4.6"], grok_effort:["none","minimal","low","medium","high","xhigh"],
     claude:["fable","sonnet","opus"], claude_effort:["low","medium","high","xhigh","max"],
-    codex:["gpt-5.6-sol"], codex_effort:["minimal","low","medium","high","xhigh"]
+    codex:["gpt-5.6-sol"], codex_effort:["minimal","low","medium","high","xhigh"],
+    opencode:[], opencode_effort:["low","medium","high"]
   };
-  var LANES = ENV.lanes || { grok:"available", claude:"available", codex:"available" };
+  var LANES = ENV.lanes || { grok:"available", claude:"available", codex:"available", opencode:"unavailable" };
   var ROSTER = ENV.roster || ["","orchestra:coordinator","orchestra:agent-builder","review:tester"];
   var HARNESS = ENV.harness || "grok";
   var AVATAR_HUE = ["#3ec9b0","#8b7cf7","#c45b7a","#c9a227","#6ea8ff","#e38f1a"];
@@ -154,12 +155,16 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
   var hist = [], hpos = -1;
 
   function uid(p){ return p + (p==="n"? nid++ : eid++); }
-  function node(o){ return Object.assign({ id:uid("n"), kind:"process", x:80, y:160, label:"Step", detail:"", lane:hostLane(), model:(modelsFor(hostLane())[0]||"grok-4.6"), effort:"medium", agentType:"", task:"", gateCmd:"", schema:"", paths:"", command:"" }, o); }
+  function node(o){ return Object.assign({ id:uid("n"), kind:"process", x:80, y:160, label:"Step", detail:"", lane:hostLane(), model:defaultModel(hostLane()), effort:"medium", agentType:"", controller:"", provider:"", disclosure:"pending", context:"", task:"", gateCmd:"", schema:"", paths:"", command:"" }, o); }
   function edge(o){ return Object.assign({ id:uid("e"), from:"", to:"", label:"", kind:"forward" }, o); }
   function hostLane(){
     if(HARNESS==="claude-code") return "claude";
     if(HARNESS==="codex") return "codex";
+    if(HARNESS==="opencode") return "opencode";
     return "grok";
+  }
+  function defaultModel(lane){
+    return modelsFor(lane)[0] || (lane==="grok" ? "grok-4.6" : "");
   }
   function staffed(n){ return n.kind==="process" || n.kind==="gate"; }
   function isShell(n){ return staffed(n) && n.lane && n.lane !== hostLane(); }
@@ -211,14 +216,12 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
   function seedMinimal(){
     nid=1; eid=1;
     var native=hostLane();
-    var nativeModel=modelsFor(native)[0]||"grok-4.6";
-    var gateLane=modelsFor("claude").length && laneAvailable("claude") ? "claude" : native;
-    var gateModel=gateLane==="claude" && modelsFor("claude").indexOf("fable")>=0 ? "fable" : (modelsFor(gateLane)[0]||nativeModel);
+    var nativeModel=defaultModel(native);
     S.name = "untitled";
     S.nodes = [
       node({id:"n1", kind:"source", x:36, y:188, label:"Start", detail:"brief in"}),
       node({id:"n2", kind:"process", x:280, y:178, label:"Work", detail:"do the job", lane:native, model:nativeModel, effort:"medium"}),
-      node({id:"n3", kind:"gate", x:530, y:178, label:"Gate", detail:"prove it", lane:gateLane, model:gateModel, effort:"high", gateCmd:"bun test"}),
+      node({id:"n3", kind:"gate", x:530, y:178, label:"Gate", detail:"prove it", lane:native, model:nativeModel, effort:"high", gateCmd:"bun test"}),
       node({id:"n4", kind:"process", x:780, y:178, label:"Done", detail:"ship or complete", lane:native, model:nativeModel, effort:"low"})
     ];
     nid=5;
@@ -429,6 +432,9 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
     }
     var n=byId(sel.id); if(!n) return;
     var native=!isShell(n);
+    var convertedExternal=HARNESS==="grok" && native && n.model && n.model!=="grok-4.6";
+    var external=isShell(n)||convertedExternal;
+    var boundary=external||n.lane==="opencode";
     var r=resolved(n);
     var fate=r.omit ? ("Not emitted: "+r.omitReason) : (r.shell ? ("Emits as CLI shell-out to "+r.lane+(r.converted?" (converted from native)":"")) : (staffed(n)?"Emits as native agent":"Emits as "+n.kind));
     aside.innerHTML="<h2>"+esc(n.label)+"</h2><p class='who'>"+esc(kindLabel(n))+"</p>"+
@@ -436,13 +442,17 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
       fsel("kind","Node type",["source","process","gate","artifact","memory"].map(function(k){return '<option '+(n.kind===k?"selected":"")+' value="'+k+'">'+k+"</option>";}).join(""))+
       ftext("label","Title",n.label)+ftext("detail","Subtitle",n.detail)+
       (staffed(n)?
-        fsel("lane","Lane",["grok","claude","codex"].map(function(k){
+        fsel("lane","Lane",["grok","claude","codex","opencode"].map(function(k){
           var miss=!laneAvailable(k);
           return '<option '+(n.lane===k?"selected":"")+' value="'+k+'">'+k+(miss?" (not installed)":"")+"</option>";
         }).join(""))+
         fsel("model","Model",modelsFor(n.lane).map(function(k){return '<option '+(n.model===k?"selected":"")+' value="'+k+'">'+k+"</option>";}).join(""))+
         fsel("effort","Effort",effortsFor(n.lane).map(function(k){return '<option '+(n.effort===k?"selected":"")+' value="'+k+'">'+k+"</option>";}).join(""))+
         (native?fsel("agentType","Agent",rosterList().map(function(k){return '<option '+(n.agentType===k.id?"selected":"")+' value="'+esc(k.id)+'">'+esc(k.name)+"</option>";}).join("")):"")+
+        (boundary?ftext("provider","Actual provider",n.provider||""):"")+
+        (external?ftext("controller","Native controller",n.controller||""):"")+
+        (boundary?fsel("disclosure","Disclosure",["pending","approved","not-required"].map(function(k){return '<option '+(n.disclosure===k?"selected":"")+' value="'+k+'">'+k+"</option>";}).join("")):"")+
+        (boundary?fta("context","Context shared",n.context||""):"")+
         ftext("paths","Owned paths",n.paths||"")+
         fta("task","Task",n.task)+
         (native?fta("schema","Structured output schema (JSON, optional)",n.schema||""):fta("command","CLI command (blank = composed)",n.command||""))
@@ -450,7 +460,7 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
       (n.kind==="gate"?fta("gateCmd","Gate command",n.gateCmd):"")+
       (r.shell && !n.command?'<p class="hint">Composed command: '+esc(r.command)+"</p>":"")+
       '<p class="hint">Change type, lane, or title — the card restyles in place. Connect cards on the graph, not in this panel.</p>';
-    bind(["kind","label","detail","lane","model","effort","agentType","paths","task","schema","gateCmd","command"], onNodeField);
+    bind(["kind","label","detail","lane","model","effort","agentType","controller","provider","disclosure","context","paths","task","schema","gateCmd","command"], onNodeField);
   }
   function fsel(id,lab,inner,note){ return '<div class="field"><label for="'+id+'">'+lab+"</label><select id='"+id+"'>"+inner+"</select>"+(note?'<p class="hint">'+note+"</p>":"")+"</div>"; }
   function ftext(id,lab,v){ return '<div class="field"><label for="'+id+'">'+lab+'</label><input id="'+id+'" type="text" value="'+esc(v)+'"></div>'; }
@@ -473,6 +483,12 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
         n.model=val("model"); n.effort=val("effort");
         if(!isShell(n)){ n.agentType=val("agentType"); n.schema=val("schema"); }
         n.task=val("task"); n.paths=val("paths"); n.command=val("command");
+        var convertedExternal=HARNESS==="grok" && !isShell(n) && n.model && n.model!=="grok-4.6";
+        var external=isShell(n)||convertedExternal;
+        if(external||n.lane==="opencode"){
+          n.provider=val("provider"); n.disclosure=val("disclosure")||"pending"; n.context=val("context");
+        }
+        if(external) n.controller=val("controller");
       }
     }
     if(n.kind==="gate") n.gateCmd=val("gateCmd");
@@ -490,7 +506,7 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
       label: kind==="gate"?"Gate": kind==="source"?"Source": kind==="artifact"?"Artifact": kind==="memory"?"Memory":"Step",
       detail: kind==="gate"?"prove the work":"",
       lane: kind==="gate" && laneAvailable("claude")?"claude":hostLane(),
-      model: kind==="gate" && modelsFor("claude").length? (modelsFor("claude").indexOf("fable")>=0?"fable":modelsFor("claude")[0]) : (modelsFor(hostLane())[0]||"grok-4.6"),
+      model: kind==="gate" && modelsFor("claude").length? (modelsFor("claude").indexOf("fable")>=0?"fable":modelsFor("claude")[0]) : defaultModel(hostLane()),
       gateCmd: kind==="gate"?"bun test":"" });
     S.nodes.push(n);
     if(sel&&sel.k==="node"&&byId(sel.id)&&sel.id!==n.id){
@@ -546,23 +562,46 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
   function composeCommand(n){
     if(n.command) return n.command;
     var dir=S.cwd || ".";
-    var task=(n.task||n.label||"task").replace(/"/g,'\\"');
+    var task=n.task||n.label||"task";
     var effort="";
     if(n.effort && n.lane==="codex") effort=' -c model_reasoning_effort="'+n.effort+'"';
     if(n.effort && n.lane==="grok") effort=" --reasoning-effort "+n.effort;
-    if(n.lane==="codex") return 'codex exec --sandbox workspace-write --cd "'+dir+'" -m "'+n.model+'"'+effort+' "'+task+'"';
-    if(n.lane==="grok") return 'grok --single "'+task+'" -m "'+n.model+'"'+effort+' --permission-mode acceptEdits --sandbox workspace --cwd "'+dir+'"';
-    if(n.lane==="claude") return 'claude --print --safe-mode --append-system-prompt-file "$HOME/.claude/communication.md" --model "'+n.model+'" --permission-mode plan --tools "Read,Grep,Glob" --no-session-persistence "'+task+'"';
+    if(n.lane==="codex") return 'codex exec --sandbox workspace-write --cd '+shQuote(dir)+' -m '+shQuote(n.model)+effort+' '+shQuote(task);
+    if(n.lane==="grok") return 'grok --single '+shQuote(task)+' -m '+shQuote(n.model)+effort+' --permission-mode acceptEdits --sandbox workspace --cwd '+shQuote(dir);
+    if(n.lane==="claude") return 'claude --print --safe-mode --append-system-prompt-file "$HOME/.claude/communication.md" --model '+shQuote(n.model)+' --permission-mode plan --tools "Read,Grep,Glob" --no-session-persistence '+shQuote(task);
+    if(n.lane==="opencode") return 'opencode run --model '+shQuote(n.model)+' --dir '+shQuote(dir)+' '+shQuote(task);
+    return "";
+  }
+  function shQuote(value){
+    return "'"+String(value||"").replace(/'/g,"'\\\"'\\\"'")+"'";
+  }
+  function boundaryIssue(n, shell){
+    if(!(shell || n.lane==="opencode")) return "";
+    if(!n.provider) return "actual provider is required";
+    if(shell && !n.controller) return "native controller is required";
+    if(!n.context) return "context shared must be stated";
+    if((n.disclosure||"pending")==="pending") return "external provider disclosure is still pending";
     return "";
   }
   function resolved(n){
     var row={
       id:n.id, kind:n.kind, label:n.label, detail:n.detail, x:n.x, y:n.y,
       lane:n.lane||null, model:n.model||null, effort:n.effort||null,
+      controller:n.controller||null, provider:n.provider||null,
+      disclosure:n.disclosure||null, context:n.context||null,
       task:n.task||"", paths:n.paths||null, gateCmd:n.kind==="gate"?n.gateCmd:null,
       shell:false, agentType:null, schema:null, command:null, converted:false, omit:false, omitReason:null
     };
     if(!staffed(n)) return row;
+    if(!n.model){
+      row.omit=true; row.omitReason="no model was detected for the "+n.lane+" lane";
+      row.shell=isShell(n); return row;
+    }
+    var issue=boundaryIssue(n,isShell(n));
+    if(issue){
+      row.omit=true; row.omitReason=issue;
+      row.shell=isShell(n); return row;
+    }
     if(!laneAvailable(n.lane) && isShell(n)){
       row.omit=true; row.omitReason="the "+n.lane+" CLI is not installed";
       row.shell=true; return row;
@@ -581,6 +620,8 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
       }
       var remapped=Object.assign({}, n, {lane:lane});
       row.shell=true; row.converted=true; row.lane=lane;
+      var convertedIssue=boundaryIssue(remapped,true);
+      if(convertedIssue){ row.omit=true; row.omitReason=convertedIssue; return row; }
       row.command=composeCommand(remapped);
       return row;
     }
@@ -600,12 +641,19 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
     S.nodes.forEach(function(n){
       if(!staffed(n)) return;
       var ms=modelsFor(n.lane);
+      if(!n.model) out.push(n.label+": no model was detected for the "+n.lane+" lane.");
       if(n.model && ms.length && ms.indexOf(n.model)<0) out.push(n.label+": "+n.model+" is not on the "+n.lane+" lane.");
       if(isShell(n) && !laneAvailable(n.lane)) out.push(n.label+": the "+n.lane+" CLI is not installed, so this shell-out cannot run here.");
       if(HARNESS==="grok" && !isShell(n) && n.model && n.model!=="grok-4.6")
         out.push(n.label+": Grok agent().model accepts grok-4.6 only; "+n.model+" will emit as a shell-out.");
       if(n.schema && isShell(n)) out.push(n.label+": structured output is native-only; schema will not be emitted.");
       if(n.agentType && isShell(n)) out.push(n.label+": roster agentType is native-only; it will not be emitted.");
+      var converted=HARNESS==="grok" && !isShell(n) && n.model && n.model!=="grok-4.6";
+      var boundary=isShell(n)||n.lane==="opencode"||converted;
+      if(boundary && !n.provider) out.push(n.label+": actual provider is required.");
+      if((isShell(n)||converted) && !n.controller) out.push(n.label+": native controller is required for visible external dispatch.");
+      if(boundary && (n.disclosure||"pending")==="pending") out.push(n.label+": provider disclosure is pending.");
+      if(boundary && !n.context) out.push(n.label+": context shared must be stated.");
     });
     if(!S.nodes.some(function(n){ return n.kind==="gate"; }))
       out.push("No gate node. Add a Gate so fail can return to an earlier step.");
@@ -622,11 +670,16 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
     if(r.shell){
       return "- **"+n.label+"** — SHELL-OUT to "+r.lane+(r.converted?" (converted from native)":"")+"\n"+
         "  model: "+(r.model||"")+" · effort: "+(r.effort||"tool default")+"\n"+
+        "  controller: "+(r.controller||"(missing)")+"\n"+
+        "  provider: "+(r.provider||"(missing)")+" · disclosure: "+(r.disclosure||"pending")+"\n"+
+        "  context: "+(r.context||"(missing)")+"\n"+
         "  command: "+r.command+(n.task?"\n  "+n.task:"");
     }
     if(staffed(n)){
       return "- **"+n.label+"** — "+person+"\n"+
-        "  model: "+(r.model||"")+" · effort: "+(r.effort||"")+(n.paths?"\n  paths: "+n.paths:"")+(n.task?"\n  "+n.task:"");
+        "  model: "+(r.model||"")+" · effort: "+(r.effort||"")+
+        (n.lane==="opencode"?("\n  provider: "+(r.provider||"(missing)")+" · disclosure: "+(r.disclosure||"pending")+"\n  context: "+(r.context||"(missing)")):"")+
+        (n.paths?"\n  paths: "+n.paths:"")+(n.task?"\n  "+n.task:"");
     }
     return "- **"+n.label+"** — "+n.kind+(n.detail?(" · "+n.detail):"");
   }
@@ -649,6 +702,7 @@ window.VC_SEED = window.VC_SEED || { name: "", nodes: [], edges: [] };
     var lines=["# Workflow: "+S.name,"Host harness: "+HARNESS+"   (fixed — set by how this session started)",
       "Isolation: "+iso,"Concurrency: "+c,"cwd: "+(S.cwd||".")];
     if(HARNESS==="codex") lines.push("Codex has no workflow runtime. The forward path becomes ordered `codex exec` calls the caller sequences.");
+    if(HARNESS==="opencode") lines.push("OpenCode has no workflow runtime. The forward path becomes ordered `opencode run` calls and `@agent` children the caller sequences.");
     lines.push("","## Graph");
     S.edges.forEach(function(e){
       var a=byId(e.from), b=byId(e.to);

--- a/modules/orchestra/skills/visual-coordinator/references/emitted-spec-format.md
+++ b/modules/orchestra/skills/visual-coordinator/references/emitted-spec-format.md
@@ -15,7 +15,7 @@ not from a hardcoded example and not from a phase list the user never saw.
 
 ````
 # Workflow: <name>
-Host harness: <claude-code|codex|grok>   (fixed — set by how this session started)
+Host harness: <claude-code|codex|grok|opencode>   (fixed — set by how this session started)
 Isolation: <shared-tree|worktree-per-agent>
 Concurrency: <n>
 cwd: <path>
@@ -30,6 +30,9 @@ cwd: <path>
   model: grok-4.6 · effort: medium
 - **Implement B** — SHELL-OUT to codex
   model: gpt-5.6-sol · effort: medium
+  controller: native-worker-2
+  provider: OpenAI · disclosure: approved
+  context: SPEC file and owned paths only
   command: codex exec ...
 
 ## Verification gate
@@ -51,6 +54,10 @@ cwd: <path>
       "model": "grok-4.6",
       "effort": "medium",
       "agentType": null,
+      "controller": "native-worker-2",
+      "provider": "OpenAI",
+      "disclosure": "approved",
+      "context": "SPEC file and owned paths only",
       "task": "<prompt>",
       "shell": false
     },
@@ -90,6 +97,12 @@ edges is a staffing list.
 `agentType` must be an id from the installed roster. `model` and `effort`
 must come from the detected lists for that lane.
 
+`controller` identifies the native child supervising an external process;
+`provider` identifies the company receiving the selected context. They are not
+the same identity. `disclosure` is `approved` | `not-required` | `pending`, and
+`context` states exactly what may cross the boundary. An external node with
+pending disclosure is retained for review but emitted with `omit: true`.
+
 `gateNode` points at the gate node. `gateCmd` on that node is the command
 that proves the work. Seed a gate if the user did not place one, and say
 it was defaulted.
@@ -108,6 +121,11 @@ runs the CLI. Fan-out uses `parallel()`. `pipeline()` is Claude-only.
 **Codex**: no workflow runtime. Translate the forward path into ordered
 `codex exec` calls. Say that sequencing is the caller's job. A reject
 edge is a second dispatch after a failed gate, not a native loop.
+
+**OpenCode**: no workflow runtime. Translate the forward path into ordered
+`opencode run --model "<provider>/<model>" --dir <repo>` calls. A named
+`mode: subagent` child is invoked with `@name`, not `--agent`. Require a child
+marker before claiming it ran. OpenCode never uses the Grok translation.
 
 **Grok**: emit a Rhai workflow. Follow the bundled `/create-workflow`
 skill. Native `agent().model` is `grok-4.6` only. A non-Grok lane is a

--- a/modules/orchestra/skills/visual-coordinator/references/visual-delivery.md
+++ b/modules/orchestra/skills/visual-coordinator/references/visual-delivery.md
@@ -1,0 +1,18 @@
+# Visual delivery policy
+
+A visual plan is complete only when the user can open it.
+
+1. On Claude Code, publish the canvas as an Artifact.
+2. On other hosts, load BitPlan's canonical skill (`bitplan:bitplan` from its
+   plugin, or `bitplan` from a standalone install). Explain that BitPlan is an
+   external provider and ask before uploading an encrypted draft.
+3. Prefer an already available BRC-100 wallet. Do not point BitPlan at `1sat
+   serve wallet`; that planned fallback is not yet application-compatible.
+4. If no compatible wallet is available, open the local HTML file.
+5. Only after the user explicitly declines the wallet paths may you offer
+   PostPlan as an unencrypted hosted fallback. Explain the consequence and ask
+   before uploading.
+
+Never stop after writing an HTML path when the host can present a usable page.
+Never upload a visual plan or its embedded repository context without the
+required provider disclosure and approval.

--- a/modules/orchestra/skills/visual-coordinator/scripts/detect-harness.sh
+++ b/modules/orchestra/skills/visual-coordinator/scripts/detect-harness.sh
@@ -98,11 +98,16 @@ esac
 # rather than a filename, and skip legacy caches so retired ids never appear.
 roster_json="[]"
 roster_json=$(
-  python3 - "$HOME/.claude/plugins/cache" "$HOME/.grok/installed-plugins" <<'PY_INNER'
+  python3 - "$HOME/.claude/plugins/cache" "$HOME/.grok/installed-plugins" \
+    "${CODEX_HOME:-$HOME/.codex}/agents" "$PWD/.opencode/agents" \
+    "$PWD/.opencode/agent" "$HOME/.config/opencode/agents" \
+    "$HOME/.config/opencode/agent" <<'PY_INNER'
 import json, os, re, sys
 
 claude_cache = sys.argv[1]
 grok_plugins = sys.argv[2]
+codex_agents = sys.argv[3]
+opencode_dirs = sys.argv[4:]
 latest = {}
 
 def field(text, name):
@@ -125,6 +130,25 @@ def add_agents(plugin_name, agents_dir):
         latest[key] = {
             "id": key,
             "display_name": field(text, "display_name") or agent_id,
+            "summary": field(text, "description")[:110],
+        }
+
+def add_flat_agents(prefix, agents_dir):
+    if not os.path.isdir(agents_dir):
+        return
+    for f in sorted(os.listdir(agents_dir)):
+        if not f.endswith(".md"):
+            continue
+        path = os.path.join(agents_dir, f)
+        try:
+            text = open(path, encoding="utf-8").read(4000)
+        except OSError:
+            continue
+        agent_id = f[:-3]
+        key = f"{prefix}:{agent_id}"
+        latest[key] = {
+            "id": key,
+            "display_name": field(text, "display_name") or field(text, "name") or agent_id,
             "summary": field(text, "description")[:110],
         }
 
@@ -160,6 +184,10 @@ if os.path.isdir(grok_plugins):
             except (OSError, json.JSONDecodeError):
                 pass
         add_agents(name, os.path.join(root, "agents"))
+
+add_flat_agents("codex", codex_agents)
+for directory in opencode_dirs:
+    add_flat_agents("opencode", directory)
 
 print(json.dumps(list(latest.values())))
 PY_INNER

--- a/modules/orchestra/skills/wave-coordinator/SKILL.md
+++ b/modules/orchestra/skills/wave-coordinator/SKILL.md
@@ -1,225 +1,113 @@
 ---
 name: wave-coordinator
-version: 1.0.8
-description: >-
-  Dispatch many subagents in coordinated waves with per-wave review. Use for "fan out agents",
-  "wave dispatch", "batch agents", "generate N variations", or any fan-out beyond about five
-  parallel subagents that needs batching, ordering, and result reconciliation.
+version: 1.0.9
+description: Dispatch many independent units in bounded waves with honest host limits, distinct assignments, barriers, and main-seat reconciliation. Use for fan-out, batch agents, many variations, or work that exceeds the host's free subagent slots.
 ---
 
 # Wave Coordinator
 
-Manage large-scale subagent dispatch through structured waves. Prevent context
-exhaustion, preserve output diversity, and avoid duplication across batches.
-On Claude, this can compose with
-`Skill(superpowers:dispatching-parallel-agents)`; on Codex, use the native
-subagent runtime. Wave Coordinator owns batching and diversity while the host
-runtime owns thread creation.
+Batch a large fan-out without losing ownership, context, or diversity. This
+skill owns wave sizing, ordering, the wave ledger, and barriers. It does not
+redefine how workers are selected or launched.
 
-## Prefer Native Workflows on Claude Code and Grok Build
+## Load the shared dispatch rules
 
-Claude Code and Grok Build provide different native workflow engines. When the
-current session exposes one and the user asked for a fan-out, prefer it over
-hand-managed waves. Load only the applicable host guide:
-[Claude Code](../coordinator/references/hosts/claude.md) or
-[Grok Build](../coordinator/references/hosts/grok.md). Codex and OpenCode keep
-the manual wave protocol below; see their respective Coordinator host guides.
+Before a wave that implements anything, read
+[Coordinator](../coordinator/SKILL.md), its
+[dispatch contract](../coordinator/references/dispatch-contract.md), exactly
+one current-host guide, and only the worker guides selected for the wave.
+Those files govern cheap-lane selection, native controllers, provider
+disclosure, isolation, specs, review, verification, and git ownership.
 
-## The Core Problem
+Use roster specialists for evidence, review, testing, and domain judgment.
+Use cheaper external workers for bounded implementation volume. Do not repeat
+host command syntax here; the selected Coordinator references are the source of
+truth.
 
-Dispatching 10+ agents at once causes three failures:
-1. **Context exhaustion** — spawning agents is expensive; running out mid-batch leaves work incomplete
-2. **Homogeneous output** — identical prompts produce near-identical results, wasting compute
-3. **Duplication** — later waves repeat what earlier waves already produced
+## Size each wave from live capacity
 
-Wave coordination solves all three.
+Start with five as a conservative planning ceiling, then use the smallest of:
 
-## Wave Sizing Rule
+1. five, unless the user deliberately chose another ceiling;
+2. the host's advertised concurrency cap;
+3. currently free native child slots;
+4. genuinely independent remaining units; and
+5. the size the remaining context can still synthesize.
 
-Use five concurrent subagents as a conservative planning default, then clamp
-the wave to the host's advertised concurrency limit, currently free thread
-slots, task shape, and remaining context/token budget. Codex defaults to
-`agents.max_threads = 6` when unset, but that is a cap on open threads, not a
-promise that all six slots are free. If N exceeds the effective limit, divide
-the work into sequential waves:
+The configured cap includes already-running children. Reserve at least 20% of
+the main context for reconciliation and the final report. If that reserve is
+at risk, shrink or stop the fan-out.
 
-```
-N=12 → Wave 1 (5) → Wave 2 (5) → Wave 3 (2)
-N=7  → Wave 1 (5) → Wave 2 (2)
-N=5  → Wave 1 (5) — single wave, no split needed
-```
-
-Each wave completes fully before the next launches. Do not launch wave 2 until
-all wave 1 agents have returned results.
-
-Compute the effective wave size as the minimum of:
-
-1. Five, unless the user or host deliberately chooses another wave size.
-2. The host-advertised concurrency cap.
-3. The number of currently free agent slots.
-4. The number of genuinely independent remaining units.
-5. The size the remaining context and token budget can safely synthesize.
-
-Never assume a configured maximum means those slots are all available.
-
-## Context Budget Check
-
-Before launching each wave, estimate context budget:
-
-1. Count tokens consumed so far (rough estimate: each spawned agent costs ~2-4k tokens in overhead)
-2. Reserve at minimum 20% of the context window for synthesis and final output
-3. If budget is tight, reduce the next wave size to 2-3 agents
-4. If budget is critically low, stop dispatching and synthesize from what you have
-
-**Hard rule:** Never launch a wave if you estimate it will hit the context limit before completion. Stop early and synthesize. Incomplete partial output is better than a context overflow crash.
-
-## Directive Diversity
-
-Each agent in a wave must receive **unique creative direction**. Do not send the same prompt to all agents in a wave.
-
-### How to generate diverse directives
-
-Before dispatching, generate N distinct emphasis angles for N agents. Vary along at least one axis:
-
-| Axis | Example variations |
-|------|--------------------|
-| Tone | formal / conversational / terse / expansive |
-| Focus | conciseness / error handling / edge cases / performance / examples |
-| Perspective | beginner / expert / skeptic / advocate |
-| Structure | prose / bullet list / table / code-first |
-| Constraint | max 200 words / no jargon / no code / examples only |
-
-**Example:** Generating 5 skill variants
-
-```
-Agent 1: "Write the most concise version possible. No examples, pure principle."
-Agent 2: "Lead with 3 concrete examples, then derive the rule."
-Agent 3: "Focus entirely on error cases and what can go wrong."
-Agent 4: "Write for someone encountering this concept for the first time."
-Agent 5: "Assume expert audience. Skip fundamentals, go deep on edge cases."
+```text
+12 independent units, five free slots
+wave 1: 5 -> barrier/review
+wave 2: 5 -> barrier/review
+wave 3: 2 -> barrier/final reconciliation
 ```
 
-Never assign the same emphasis to two agents in the same wave.
+Never start the next wave until the prior wave has returned complete reports
+and the main has recorded what remains.
 
-## Deduplication Check
+## Make units distinct
 
-Before launching each wave after the first:
+Every unit needs exclusive ownership and a different purpose. For creative
+variants, vary a real axis such as audience, risk posture, structure, or tone.
+For implementation, split at file or interface boundaries and pin shared seams
+verbatim in every affected spec.
 
-1. Read the output produced by all prior waves
-2. Identify themes, approaches, or content already covered
-3. Add exclusion instructions to the new wave's directives: "Do NOT produce a version similar to [description of prior output]"
-4. If a prior wave already produced a high-quality result for a particular angle, skip that angle in subsequent waves
+Before wave two and later:
 
-## Wave Progress Tracking
+1. read all accepted output from earlier waves;
+2. record approaches already covered;
+3. exclude duplicates explicitly from the new assignments; and
+4. drop units whose intended outcome already exists.
 
-Maintain a mental (or written) wave ledger before each dispatch:
+## Keep a wave ledger
 
+Track the facts needed for the next decision:
+
+```text
+wave 1 - 4/4 returned; 3 accepted; 1 correction pending
+providers - OpenAI via Codex (2), Muse via OpenCode (2)
+controllers - four native child ids
+shared context - SPEC files only; no secrets
+remaining - API adapter, regression test, reconciliation
 ```
-Wave 1: [5 agents] — launched, awaiting results
-Wave 2: [5 agents] — pending (blocked on wave 1)
-Wave 3: [2 agents] — pending (blocked on wave 2)
 
-Output so far: [list of completed items]
-Remaining: [list of items not yet produced]
-```
+The ledger must distinguish the visible native controller from the external
+provider/model that performed implementation. An idle or completed controller
+is lifecycle evidence, not proof that the external process succeeded.
 
-Update the ledger after each wave completes. This prevents re-dispatching work already done and helps identify what the final synthesis pass needs.
+## Run barriers in the main
 
-## Host Dispatch Adapters
+At every barrier, the main:
 
-Before assigning a wave slot to a generic worker, match it against the roster
-in `../deploy-agent-team/references/agent-roster.md` and pass the specific
-`subagent_type` (e.g. `review:code-auditor`). Each wave slot picks a
-roster agent before defaulting to a generic explorer/worker — use the generic
-adapter only when no roster agent fits, and say so explicitly in the wave
-ledger.
+- reads complete reports and actual diffs;
+- rejects edits outside assigned ownership;
+- records provider, model, disclosure state, and context shared;
+- runs the relevant acceptance gate unpiped; and
+- updates the ledger before dispatching again.
 
-### Grok Build
+Independent units may run concurrently. Integration, cross-unit fixes, final
+verification, and all git operations wait behind the barrier.
 
-Use `spawn_subagent` with the installed roster `subagent_type` (e.g.
-`research:researcher`, `review:code-auditor`). `bopen-tools:<name>` aliases
-also resolve when that plugin is installed. Native `agent().model` is
-`grok-4.6` only. Do not dispatch `grok-4.5`. Run Sol as
-`grok --single -m gpt-5.6-sol` inside a supervisor, or `codex exec`.
-Prefer the native `workflow` tool over hand waves when the fan-out has
-shape. Live children default to 32; `agent_budget` defaults to 128.
+## Host shape
 
-### Claude Code
+Use the current-host guide for exact primitives:
 
-Use `Skill(superpowers:dispatching-parallel-agents)` when installed. Otherwise
-use Claude Code's native Agent tool and plugin-qualified agent IDs. Preserve one
-self-contained assignment per agent.
+- Claude Code and Grok Build may offer native workflow engines.
+- Codex uses native children and main-thread barriers; account for occupied
+  slots and do not raise global depth without approval.
+- OpenCode has agents and `opencode run`, not a multi-stage workflow engine;
+  the caller sequences waves and verifies child markers.
 
-### Codex
+When the host supports native children, each external worker runs beneath a
+visible native controller. When it does not, the main may dispatch directly as
+specified by the host guide and must still preserve the same ledger fields.
 
-Use Codex native subagents. Prefer installed `bopen_*` custom agents for named
-specialists and built-in `worker` or `explorer` agents when no matching custom
-adapter exists. Do not claim a `bopen_*` persona was used unless that adapter is
-actually installed and its thread was spawned.
+## Finish
 
-Codex defaults to `agents.max_threads = 6` and `agents.max_depth = 1` when the
-user leaves them unset. Depth 1 lets the main thread spawn direct children but
-prevents those children from recursively spawning their own agents. Keep wave
-coordination in the main thread under that default. If a workflow genuinely
-requires nested delegation, explain the token and runaway-fan-out risk before
-the user raises `agents.max_depth`; never change global Codex configuration as
-part of this skill.
-
-Use `/agent` or the available agent activity view to inspect active and
-completed threads. Account for already-open threads when calculating the next
-wave.
-
-### OpenCode
-
-Use native OpenCode agents (`.opencode/agent(s)/<name>.md`) with the installed
-roster id where one fits. `--agent <name>` selects a primary/all-mode agent,
-not a subagent; invoke a real child from the primary with `@name`, as defined
-by Coordinator. Pin and verify the parent model, then require a child marker
-in the log before counting the run as delegated. There is no native multi-stage
-workflow engine: the caller sequences dispatches and owns barriers.
-
-## Integration with superpowers
-
-Wave-coordinator handles **what** to dispatch and **when**. `Skill(superpowers:dispatching-parallel-agents)` handles **how** to spawn subagents. Use them together:
-
-1. Use this skill to plan wave sizes, generate diverse directives, and track progress
-2. Use `Skill(superpowers:dispatching-parallel-agents)` for the actual subagent spawning call syntax
-
-If the superpowers plugin is not installed, use the current host's native
-subagent runtime instead. Do not silently degrade: state whether the wave uses
-Claude agents, Codex custom/built-in agents, or another explicitly authorized
-worker lane.
-
-## Worked Example
-
-**Task:** Generate 8 variations of a landing page headline.
-
-**Wave plan:**
-
-Wave 1 (5 agents):
-- Agent A: Urgency angle ("Limited time, immediate benefit")
-- Agent B: Social proof angle ("Join 10,000+ users who...")
-- Agent C: Problem-first angle ("Tired of X? Meet Y.")
-- Agent D: Benefit-first angle ("Do X in half the time.")
-- Agent E: Curiosity angle ("The surprising way to X")
-
-Collect wave 1 output. Review for quality and coverage.
-
-Wave 2 (3 agents — note: reduced from 5 because only 3 remain):
-- Check wave 1 output first
-- Agent F: Contrast angle not yet covered
-- Agent G: Minimalist / single-word-impact angle
-- Agent H: Question format not yet tried
-
-Synthesize all 8 results. Rank by quality. Present top 3 with rationale.
-
-## Key Rules
-
-- Five agents per wave is the conservative planning default; clamp it to the host cap and currently free slots
-- Codex's default six-thread cap includes already-open threads; it is not a six-new-agent allowance
-- Keep orchestration at the main thread when Codex `max_depth` remains at its safe default of 1
-- Check context budget before each wave
-- Unique directive per agent — never duplicate prompts within a wave
-- Read prior output before launching the next wave
-- Stop and synthesize if budget runs low — do not push through to completion at the cost of a crash
-- Wave 2+ directives must explicitly exclude angles already covered in prior waves
+Synthesize accepted results rather than concatenating them. Report wave sizes,
+controllers, actual providers/models, rejected or retried units, gates run, and
+remaining uncertainty. Never claim a roster agent, provider, or model ran
+without evidence.


### PR DESCRIPTION
## Summary

- make Coordinator’s cheap-worker/native-controller/provider-boundary contract authoritative across Orchestra
- slim Wave Coordinator, Software Factory, Deploy Agent Team, and Advisor into progressive entrypoints with narrow references
- fix malformed external worker commands
- give Visual Coordinator a real OpenCode lane instead of silently falling through to Grok
- add controller, actual provider, disclosure state, and shared-context fields to visual plans
- discover Codex and OpenCode roster adapters and extract BitPlan delivery policy into one reference
- add deterministic contract checks to prevent drift

## Review notes

The default visual graph now stays on the current native host, so it begins valid. Selecting an external worker or reviewer explicitly requires its provider, supervising native controller, disclosure state, and context boundary.

No provider identity is guessed. OpenCode model selection remains discovery-driven.

## Validation

- Orchestra deterministic contract checks
- Claude/Codex manifest parity and docs inventory
- marketplace extraction for every plugin
- isolated plugin installation
- detector shell syntax and JSON output
- visual canvas JavaScript parse and browser smoke test
- `git diff --check`

A broader Python discovery run has one environment-only failure because this host Python lacks the newer `tarfile.extractall(filter=...)` API; the repository’s targeted gates pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791135136&installation_model_id=435537&pr_number=50&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F50&signature=2de6047617c8c87b5f61fdf8ad841814fd7ff3354a9b20efc089ffe4573c2c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->