### PR TITLE
fix(orchestra): detect OpenCode models in sandboxes

### DIFF
--- a/modules/orchestra/skills/visual-coordinator/scripts/detect-harness.sh
+++ b/modules/orchestra/skills/visual-coordinator/scripts/detect-harness.sh
@@ -148,12 +148,32 @@ opencode_providers=$(printf '%s\n' "$opencode_providers" \
   | head -24)
 unset _cfg _kind _value
 opencode_models=""
+# OpenCode writes its runtime database and logs below XDG_DATA_HOME even for a
+# read-only inventory query. The host may deliberately make the user's normal
+# data directory read-only (for example, a Codex worker sandbox), so give this
+# short-lived probe an isolated writable data home. Leave XDG_CONFIG_HOME and
+# HOME alone: OpenCode still reads the user's configured providers and models,
+# while the temporary directory is removed when this detector exits.
+opencode_data_home=""
+if [[ "$opencode_bin" == "available" ]]; then
+  opencode_data_home=$(mktemp -d "${TMPDIR:-/tmp}/bopen-opencode-data.XXXXXX" 2>/dev/null || true)
+  if [[ -n "$opencode_data_home" ]]; then
+    trap '[[ -n "${opencode_data_home:-}" ]] && rm -rf -- "$opencode_data_home"' EXIT
+  fi
+fi
+run_opencode_models() {
+  if [[ -n "$opencode_data_home" ]]; then
+    XDG_DATA_HOME="$opencode_data_home" opencode models "$@"
+  else
+    opencode models "$@"
+  fi
+}
 if [[ "$opencode_bin" == "available" ]]; then
   if [[ -n "$opencode_providers" ]]; then
     while IFS= read -r _provider; do
       [[ -n "$_provider" ]] || continue
       opencode_models=$(printf '%s\n%s' "$opencode_models" \
-        "$(opencode models "$_provider" 2>/dev/null \
+        "$(run_opencode_models "$_provider" 2>/dev/null \
           | awk -v provider="$_provider" '
             {
               token = $1
@@ -167,7 +187,7 @@ if [[ "$opencode_bin" == "available" ]]; then
   else
     # No local provider IDs: retain a bounded compatibility fallback for older
     # CLIs whose unscoped command is the only available inventory source.
-    opencode_models=$(opencode models 2>/dev/null \
+    opencode_models=$(run_opencode_models 2>/dev/null \
       | awk '{ token=$1; if (token ~ /^[A-Za-z0-9._-]+\/[A-Za-z0-9._:@\/-]+$/) print token }' \
       | head -1200)
   fi

--- a/scripts/tests/test_check_docs.py
+++ b/scripts/tests/test_check_docs.py
@@ -235,6 +235,50 @@ class VisualWorkflowContractTests(unittest.TestCase):
             self.assertNotIn("do-not-log", result.stdout)
             self.assertNotIn("do-not-log", result.stderr)
 
+    def test_detector_redirects_opencode_data_home_for_read_only_sandbox(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            readonly_data = temp / "readonly-data"
+            readonly_data.mkdir()
+            readonly_data.chmod(0o500)
+            config_dir = temp / ".config" / "opencode"
+            config_dir.mkdir(parents=True)
+            (config_dir / "opencode.json").write_text(
+                '{"provider":{"alpha":{"models":{"first":{}}}}}\n',
+                encoding="utf-8",
+            )
+            fake = temp / "opencode"
+            fake.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ -z \"${XDG_DATA_HOME:-}\" || \"$XDG_DATA_HOME\" == \"$OPENCODE_READONLY_DATA\" ]]; then\n"
+                "  printf '%s\\n' 'OpenCode received its read-only data home' >&2\n"
+                "  exit 17\n"
+                "fi\n"
+                "mkdir -p \"$XDG_DATA_HOME/opencode\"\n"
+                "printf '%s\\n' 'alpha/first'\n",
+                encoding="utf-8",
+            )
+            fake.chmod(0o755)
+            env = dict(os.environ)
+            env.update({
+                "HOME": str(temp),
+                "PATH": f"{temp}:/usr/bin:/bin",
+                "XDG_DATA_HOME": str(readonly_data),
+                "OPENCODE_READONLY_DATA": str(readonly_data),
+                "BOPEN_HOST_HARNESS": "codex",
+            })
+            try:
+                result = subprocess.run(
+                    ["bash", str(self.DETECTOR)], cwd=self.ROOT, env=env,
+                    capture_output=True, text=True, check=True,
+                )
+            finally:
+                readonly_data.chmod(0o700)
+            detected = json.loads(result.stdout)
+            self.assertEqual(detected["models"]["opencode"], ["alpha/first"])
+            self.assertNotIn("read-only data home", result.stdout)
+            self.assertNotIn("read-only data home", result.stderr)
+
     def test_clean_tree_passes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Problem

OpenCode is installed and its model inventory is available, but `opencode models` still initializes its runtime data and logs. In a Codex worker sandbox the normal data directory can be read-only, causing Visual Coordinator to show an empty OpenCode model list and fall back to custom entry.

## Change

- run inventory-only OpenCode model probes with a short-lived writable `XDG_DATA_HOME`
- preserve the user's normal `HOME` and configuration discovery
- clean the temporary probe directory on exit
- add a deterministic read-only-data-home regression test

## Verification

- all 8 Visual Workflow contract tests pass
- installed-path smoke test discovers 80 ranked OpenCode models, with Muse Spark first
- Codex, Claude, Grok, and OpenCode lanes remain available
- `bash -n` and `git diff --check` pass
- Ponytail review found no P0/P1 blockers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791146858&installation_model_id=435537&pr_number=52&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F52&signature=6b6baf829d3eec06961d2a8563beec9e1fce1e06af81065453c38bf9ed2e0b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->