### PR TITLE
Add native OpenCode suite support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
-  "version": "1.1.160",
-  "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code, Codex, and Grok Build",
+  "version": "1.1.161",
+  "description": "Cross-agent development skills, hooks, orchestration, and native adapters for Claude Code, Codex, Grok Build, and OpenCode",
   "author": {
     "name": "b-open-io",
     "url": "https://github.com/b-open-io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
-  "version": "1.1.160",
-  "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code, Codex, and Grok Build",
+  "version": "1.1.161",
+  "description": "Cross-agent development skills, hooks, orchestration, and native adapters for Claude Code, Codex, Grok Build, and OpenCode",
   "author": {
     "name": "b-open-io",
     "url": "https://github.com/b-open-io"

--- a/.github/workflows/opencode-native.yml
+++ b/.github/workflows/opencode-native.yml
@@ -1,0 +1,24 @@
+name: Native OpenCode
+on:
+  pull_request:
+  push:
+    branches: [dev, master]
+permissions:
+  contents: read
+jobs:
+  opencode-native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Adapter and setup regression tests
+        run: bun test opencode skills/setup/scripts/emitter.test.ts skills/setup/playground/src/lib/pack-dependencies.test.ts
+      - name: Install tested native runtime
+        run: npm install --global opencode-ai@1.18.20
+      - name: Verify native discovery without model requests
+        run: bash scripts/test-opencode-install.sh

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "core",
-  "version": "1.1.160",
-  "description": "Cross-agent development skills, hooks, orchestration, and optional custom-agent adapters for Claude Code, Codex, and Grok Build",
+  "version": "1.1.161",
+  "description": "Cross-agent development skills, hooks, orchestration, and native adapters for Claude Code, Codex, Grok Build, and OpenCode",
   "author": {
     "name": "b-open-io",
     "url": "https://github.com/b-open-io"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ manifests share the same release version.
 
 ## Unreleased
 
+## [1.1.161] - 2026-09-04
+
+### Added
+
+- Native OpenCode suite adapter over canonical agent, command and skill sources,
+  with compatible MCP registration and a reviewed core hook bridge. Scoped or
+  whole-suite installation owns one entrypoint, preserves user configuration,
+  and supports additive updates and removal.
+- Bounded HammerTime follow-up turns with cancellation/error checks, per-session
+  caps and private transcript normalization. Native guard checks preserve source
+  restrictions; unsupported confirmation requests block instead of granting access.
+- Explicit per-module OpenCode compatibility declarations, real CLI discovery
+  verification and regression coverage for installer ownership, credentials,
+  source containment, permissions and continuation lifecycle.
+
+### Fixed
+
+- Setup no longer treats Claude plugin installation as OpenCode support. Native
+  install/update/removal plans and hook configuration use OpenCode's actual paths.
+- HammerTime commands now share the same resolved state directory on every host;
+  pause/resume no longer assumes a legacy Claude directory or suggests bypassing guards.
+  Host apps, arbitrary hook registries and headless Stop parity remain documented
+  limitations rather than advertised capabilities.
+
 ## [1.1.160] - 2026-09-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ This repository provides:
 - **Specialized AI agents** for design, security, documentation, architecture,
   testing, payments, infrastructure, and more
 - **Cross-agent skills** shared by Claude Code, Codex, Grok Build, and OpenCode
-  (`SKILL.md` is drop-in on OpenCode — it also reads `.claude/skills/`)
+  with source-preserving native OpenCode skill discovery
 - **Runtime-specific hooks** that preserve the same safety and workflow intent
   on Claude Code (`claude-hooks.json`), Codex (`codex-hooks.json`), and Grok
-  Build (`hooks/hooks.json`). OpenCode has no hooks file — the equivalent is a
-  plugin event handler (`.opencode/plugin(s)/*.ts`)
+  Build (`hooks/hooks.json`), plus a native OpenCode plugin bridge
 - **Agent Master setup UI** for auditing the local harness, viewing purchased
   packs, opening advertised skill interfaces, and building runtime-specific
   setup plans without silently installing anything
@@ -27,12 +26,26 @@ This repository provides:
   cheaper implementation workers in visible native controllers, support a
   read-only Fable advisor, and let humans edit the plan on an AI Elements
   workflow canvas before execution
-- **Claude Code slash commands** for common workflows
+- **Slash commands** for common workflows, including native OpenCode command registration
 
 See [CHANGELOG.md](CHANGELOG.md) for release notes and the reconstructed
 historical baseline.
 
 ## Installation
+
+OpenCode now has a [native suite installer](opencode/README.md). From a persistent
+checkout, run `bun opencode/install.ts --all --global`, or select modules with
+`--plugin core --plugin orchestra`. It registers the same agents, commands,
+skills and supported MCP definitions, plus core's hook bridge. Restart OpenCode
+and inspect `opencode debug config`, `opencode debug skill`, and
+`opencode debug agent bopen-core-front-desk`. The tested source inventory exposes
+30 agents, 14 commands and 85 discovered skills across the suite.
+
+HammerTime uses bounded follow-up turns in persistent OpenCode sessions. Guard
+requests for additional confirmation block with an explanation; native host
+permissions remain in force. See the adapter guide for update/removal steps,
+headless behavior, and unsupported host-specific capabilities.
+
 
 `core` holds the shared foundation: session context, setup and hook
 management, completion auditing, session recall, routing, identity work, and
@@ -523,6 +536,20 @@ bun skills/setup/scripts/server.ts --runtime <claude|codex|grok|opencode|hermes|
 **Moved to Plugin:** Statusline is now distributed as the `claude-peacock` plugin.
 
 ### Installation
+
+OpenCode now has a [native suite installer](opencode/README.md). From a persistent
+checkout, run `bun opencode/install.ts --all --global`, or select modules with
+`--plugin core --plugin orchestra`. It registers the same agents, commands,
+skills and supported MCP definitions, plus core's hook bridge. Restart OpenCode
+and inspect `opencode debug config`, `opencode debug skill`, and
+`opencode debug agent bopen-core-front-desk`. The tested source inventory exposes
+30 agents, 14 commands and 85 discovered skills across the suite.
+
+HammerTime uses bounded follow-up turns in persistent OpenCode sessions. Guard
+requests for additional confirmation block with an explanation; native host
+permissions remain in force. See the adapter guide for update/removal steps,
+headless behavior, and unsupported host-specific capabilities.
+
 
 ```bash
 /plugin marketplace add b-open-io/claude-plugins

--- a/commands/hammertime.md
+++ b/commands/hammertime.md
@@ -11,6 +11,21 @@ You manage HammerTime rules — behavioral guardrails that run as a Stop hook to
 
 **Related command:** `/hammertime:manage` — Interactive management (enable, disable, remove, view, test rules)
 
+## Resolve the state directory
+
+Before reading or writing HammerTime state, use its shared resolver:
+
+```bash
+HAMMERTIME_HOME="$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/hammertime/scripts/hammertime_paths.py")" && printf '%s\n' "$HAMMERTIME_HOME"
+```
+
+Use the printed absolute directory for file-tool operations. Shell variables do
+not persist between tool calls; repeat this assignment in the same shell as any
+subsequent state operation, and stop that operation if resolution fails. The
+resolver honors `BOPEN_HAMMERTIME_HOME`, preserves an existing legacy state
+directory, and otherwise chooses the shared default. Do not hardcode a
+harness-specific location or move existing state.
+
 ## Interpret the User's Intent
 
 The user's argument (after `/hammertime`) tells you what to do:
@@ -32,12 +47,16 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/hammertime/scripts/create-timer.py" "<dura
 
 The script:
 - Computes the correct deadline using the system clock
-- Writes the rule directly to `~/.claude/hammertime/rules.json`
+- Writes the rule directly to `$HAMMERTIME_HOME/rules.json`
 - Prints JSON with the timer details: `{"name": "...", "duration": "...", "deadline": "...", "rule": "..."}`
 
 If the user provides no description after the duration, omit the description argument (the script defaults to a generic focus message).
 
-After the script runs, check if HammerTime is paused: `test -f ~/.claude/hammertime/disabled && echo "PAUSED"`.
+After the script runs, check if HammerTime is paused:
+
+```bash
+HAMMERTIME_HOME="$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/hammertime/scripts/hammertime_paths.py")" && test -f "$HAMMERTIME_HOME/disabled" && echo "PAUSED"
+```
 
 If **not** paused, show:
 1. "Timer set for **{duration}** — expires at **{deadline}**"
@@ -65,7 +84,7 @@ Example: `/hammertime always fix all pre-existing issues`
 Example: `/hammertime when you find lint errors, invoke Skill(simplify) to clean them up`
 Example: `/hammertime never say everything looks good when there are warnings`
 
-Read `~/.claude/hammertime/rules.json` first (may not exist).
+Read `$HAMMERTIME_HOME/rules.json` first (may not exist).
 
 #### Step 1: Mine real examples from production logs
 
@@ -118,7 +137,7 @@ For builtin rules, add an override entry with `enabled: false` to disable.
 
 ## After Any Change
 
-1. Write the updated rules array to `~/.claude/hammertime/rules.json` (create `~/.claude/hammertime/` directory if needed)
+1. Write the updated rules array to `$HAMMERTIME_HOME/rules.json` (create the resolved directory if needed; preserve unrelated state files)
 2. Show the **complete rules table** — all rules, not just the one that changed. Use sequential numbering starting from 1 (matching array order). Include the builtin `project-owner` rule as #0.
 
    | # | Rule | Status | Scope | Threshold | Full Turn |
@@ -127,5 +146,5 @@ For builtin rules, add an override entry with `enabled: false` to disable.
    | 1 | `rule-name` | enabled/disabled | prefix or global | N | yes/no |
    | ... | ... | ... | ... | ... | ... |
 
-3. Check if HammerTime is paused: `test -f ~/.claude/hammertime/disabled && echo "PAUSED"`. If paused, warn: **"Note: HammerTime is currently paused. This rule has been saved but won't fire until you run `/hammertime:start`."**
-4. Remind: **"Restart Claude Code for changes to take effect."**
+3. Resolve the state directory again and check `$HAMMERTIME_HOME/disabled` using the pause-check command above. If paused, warn: **"Note: HammerTime is currently paused. This rule has been saved but won't fire until you run `/hammertime:start`."**
+4. Confirm that rule changes are read on the next HammerTime evaluation. If paused, they remain inactive until HammerTime resumes.

--- a/commands/hammertime/manage.md
+++ b/commands/hammertime/manage.md
@@ -8,6 +8,20 @@ user-invocable: true
 
 Guide the user through managing their HammerTime rules interactively.
 
+## Resolve the state directory
+
+Run the canonical resolver before reading or writing state:
+
+```bash
+HAMMERTIME_HOME="$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/hammertime/scripts/hammertime_paths.py")" && printf '%s\n' "$HAMMERTIME_HOME"
+```
+
+Use the printed absolute directory for file operations and substitute it for
+`<resolved-home>` in the delegated prompts below. Repeat the resolver assignment
+in the same shell as any later state operation; shell variables do not persist
+between tool calls. Stop on resolution failure. Preserve the resolver's choice
+of override, existing legacy state, or shared default; do not move state.
+
 ## Step 1: Load current state via subagent
 
 Delegate to a subagent to read and format the current rules. Do not read rule files in the main context.
@@ -18,7 +32,7 @@ Agent(prompt: "Read HammerTime rules and return a Markdown table.
 BUILTIN RULES (always present):
 1. project-owner (builtin, enabled) — Fix all errors instead of dismissing them as pre-existing. (evaluate_full_turn: true)
 
-Read ~/.claude/hammertime/rules.json (may not exist — that means no user rules).
+Read <resolved-home>/rules.json (may not exist — that means no user rules).
 Use columns: #, Rule, Status, Scope, Summary. Show cwd_prefix in Scope, joining
 arrays with commas; show 'global' when cwd_prefix is absent.
 For timer rules (rules with a 'deadline' field), also show the deadline and remaining time (or 'EXPIRED').
@@ -71,7 +85,7 @@ Ask which rule (by number or name). Cannot remove builtin rules — tell the use
 Delegate to a subagent to read and format the full rule config:
 
 ```
-Agent(prompt: "Read ~/.claude/hammertime/rules.json and return the full config for rule '<name>'.
+Agent(prompt: "Read <resolved-home>/rules.json and return the full config for rule '<name>'.
 Show: name, rule text, enabled, cwd_prefix (or global when absent), keywords (numbered), intent_patterns (with explanation of what each catches), dismissal_verbs, qualifiers, confidence_threshold, evaluate_full_turn, skill.
 If it's the builtin 'project-owner' rule, use the hardcoded values: 15 keywords, 8 intent patterns, co-occurrence configured, threshold 5, evaluate_full_turn true.",
 subagent_type: "general-purpose")
@@ -92,15 +106,17 @@ Say goodbye and exit.
 
 ## Step 4: After any change
 
-1. Write updated rules to `~/.claude/hammertime/rules.json` (create `~/.claude/hammertime/` if needed)
+1. Write updated rules to `<resolved-home>/rules.json` (create `<resolved-home>/` if needed)
 2. Show the change
-3. Check if HammerTime is paused: `test -f ~/.claude/hammertime/disabled && echo "PAUSED"`. If paused, warn: **"Note: HammerTime is currently paused. This change has been saved but won't take effect until you run `/hammertime:start`."**
+3. Resolve the state directory again and check for `<resolved-home>/disabled`. If paused, warn: **"Note: HammerTime is currently paused. This change has been saved but won't take effect until you run `/hammertime:start`."**
 4. Ask: "Want to do anything else?" — if yes, return to Step 2
-5. Remind: **"Restart Claude Code for changes to take effect."**
+5. Confirm that rule changes are read on the next HammerTime evaluation; paused rules remain inactive until resumed.
 
 ## Important
 
 - Always read the current rules file before making changes (it may have been edited externally)
 - Never modify builtin rules in the hook source — only add user overrides
 - When showing rules, clearly distinguish builtin from user rules
-- Create `~/.claude/hammertime/` directory if it doesn't exist when writing
+- Create `<resolved-home>/` directory if it doesn't exist when writing
+
+- If a host guard blocks a state operation, report the block rather than bypassing it or claiming success.

--- a/commands/hammertime/start.md
+++ b/commands/hammertime/start.md
@@ -6,13 +6,13 @@ user-invocable: true
 
 # HammerTime Start
 
-Re-enable the HammerTime stop hook by removing the sentinel file. Use Python to bypass the damage-control hook's `noDeletePaths` rule on `~/.claude/`:
+Re-enable HammerTime by resolving its shared state directory and removing only the pause sentinel:
 
 ```bash
-python3 -c "import os; p=os.path.expanduser('~/.claude/hammertime/disabled'); os.path.exists(p) and os.remove(p)"
+HAMMERTIME_HOME="$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/hammertime/scripts/hammertime_paths.py")" && rm -f -- "$HAMMERTIME_HOME/disabled" && test ! -e "$HAMMERTIME_HOME/disabled"
 ```
 
-Then confirm to the user:
+If the command fails or a host guard blocks it, report the failure and do not bypass the guard or claim success. After a successful check, confirm to the user:
 
 ```
 HammerTime active. All enabled rules are now enforced.

--- a/commands/hammertime/stop.md
+++ b/commands/hammertime/stop.md
@@ -6,13 +6,13 @@ user-invocable: true
 
 # HammerTime Stop
 
-Disable the HammerTime stop hook by creating the sentinel file:
+Pause HammerTime by resolving its shared state directory and creating only the pause sentinel:
 
 ```bash
-mkdir -p ~/.claude/hammertime && touch ~/.claude/hammertime/disabled
+HAMMERTIME_HOME="$(python3 "${CLAUDE_PLUGIN_ROOT}/skills/hammertime/scripts/hammertime_paths.py")" && mkdir -p -- "$HAMMERTIME_HOME" && touch -- "$HAMMERTIME_HOME/disabled" && test -f "$HAMMERTIME_HOME/disabled"
 ```
 
-Then confirm to the user:
+If the command fails or a host guard blocks it, report the failure and do not bypass the guard or claim success. After a successful check, confirm to the user:
 
 ```
 HammerTime paused. The stop hook will not fire until you run `/hammertime:start`.

--- a/modules/brand-rep/.claude-plugin/plugin.json
+++ b/modules/brand-rep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-rep",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Personas for public-facing surfaces, intended for deployments that answer customers rather than developers",
   "author": {
     "name": "b-open-io",

--- a/modules/brand-rep/.codex-plugin/plugin.json
+++ b/modules/brand-rep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brand-rep",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Personas for public-facing surfaces, intended for deployments that answer customers rather than developers",
   "author": {
     "name": "b-open-io",

--- a/modules/brand-rep/opencode/manifest.json
+++ b/modules/brand-rep/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "brand-rep"
+}

--- a/modules/creative/.claude-plugin/plugin.json
+++ b/modules/creative/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "creative",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "3D, shaders, game and desktop interfaces, UI audio themes, and generated media",
   "author": {
     "name": "b-open-io",

--- a/modules/creative/.codex-plugin/plugin.json
+++ b/modules/creative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "creative",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "3D, shaders, game and desktop interfaces, UI audio themes, and generated media",
   "author": {
     "name": "b-open-io",

--- a/modules/creative/opencode/manifest.json
+++ b/modules/creative/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "creative"
+}

--- a/modules/dev-ops/.claude-plugin/plugin.json
+++ b/modules/dev-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-ops",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Deployment, CI, infrastructure health, spend tracking, and payment integrations",
   "author": {
     "name": "b-open-io",

--- a/modules/dev-ops/.codex-plugin/plugin.json
+++ b/modules/dev-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-ops",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Deployment, CI, infrastructure health, spend tracking, and payment integrations",
   "author": {
     "name": "b-open-io",

--- a/modules/dev-ops/opencode/manifest.json
+++ b/modules/dev-ops/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "dev-ops"
+}

--- a/modules/mcp-dev/.claude-plugin/plugin.json
+++ b/modules/mcp-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP servers and MCP Apps, including the json-render framework for interactive in-chat UI",
   "author": {
     "name": "b-open-io",

--- a/modules/mcp-dev/.codex-plugin/plugin.json
+++ b/modules/mcp-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP servers and MCP Apps, including the json-render framework for interactive in-chat UI",
   "author": {
     "name": "b-open-io",

--- a/modules/mcp-dev/opencode/manifest.json
+++ b/modules/mcp-dev/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "mcp-dev"
+}

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/opencode/manifest.json
+++ b/modules/orchestra/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "orchestra"
+}

--- a/modules/plugin-kit/.claude-plugin/plugin.json
+++ b/modules/plugin-kit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-kit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Authoring and releasing Claude Code and Codex plugins: agent lifecycle, skill benchmarks, settings, and publishing",
   "author": {
     "name": "b-open-io",

--- a/modules/plugin-kit/.codex-plugin/plugin.json
+++ b/modules/plugin-kit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-kit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Authoring and releasing Claude Code and Codex plugins: agent lifecycle, skill benchmarks, settings, and publishing",
   "author": {
     "name": "b-open-io",

--- a/modules/plugin-kit/opencode/manifest.json
+++ b/modules/plugin-kit/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "plugin-kit"
+}

--- a/modules/research/.claude-plugin/plugin.json
+++ b/modules/research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "research",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Multi-source research, X/Twitter analysis, writing-style capture, and documentation",
   "author": {
     "name": "b-open-io",

--- a/modules/research/.codex-plugin/plugin.json
+++ b/modules/research/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "research",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Multi-source research, X/Twitter analysis, writing-style capture, and documentation",
   "author": {
     "name": "b-open-io",

--- a/modules/research/opencode/manifest.json
+++ b/modules/research/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "research"
+}

--- a/modules/review/.claude-plugin/plugin.json
+++ b/modules/review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Code review, security auditing, and exploratory testing with visual review artifacts",
   "author": {
     "name": "b-open-io",

--- a/modules/review/.codex-plugin/plugin.json
+++ b/modules/review/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Code review, security auditing, and exploratory testing with visual review artifacts",
   "author": {
     "name": "b-open-io",

--- a/modules/review/opencode/manifest.json
+++ b/modules/review/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "review"
+}

--- a/modules/web-dev/.claude-plugin/plugin.json
+++ b/modules/web-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Frontend development for Next.js and React: performance, component design, and browser inspection",
   "author": {
     "name": "b-open-io",

--- a/modules/web-dev/.codex-plugin/plugin.json
+++ b/modules/web-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Frontend development for Next.js and React: performance, component design, and browser inspection",
   "author": {
     "name": "b-open-io",

--- a/modules/web-dev/opencode/manifest.json
+++ b/modules/web-dev/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "web-dev"
+}

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,90 @@
+# OpenCode native suite adapter
+
+This is a native OpenCode plugin over the same source files used by our other
+harnesses. It registers agents, slash commands, skill directories and compatible
+MCP definitions through OpenCode's configuration hook, then bridges core's
+reviewed shell/Python safeguards into native lifecycle hooks. There is no second
+set of authored agents or skills to keep synchronized.
+
+## Install
+
+Requires OpenCode 1.18.20 or later, Bun (with `Bun.YAML`), and a persistent checkout.
+Core hooks also require Python 3, bash, and jq. Run from the project you want to configure:
+
+```sh
+git clone https://github.com/b-open-io/prompts.git "$HOME/.local/share/bopen-opencode"
+bun "$HOME/.local/share/bopen-opencode/opencode/install.ts" --all
+```
+
+Use `--plugin core --plugin orchestra` instead of `--all` to select modules.
+Use `--global` to install for all projects, or `--project /path/to/project` for
+an explicit project. `--dry-run` prints inventory and compatibility warnings
+without changing files. An individual module page must select its module, never
+silently expand to the entire suite.
+
+Restart OpenCode, then inspect native discovery:
+
+```sh
+opencode debug config
+opencode debug agent bopen-core-front-desk
+opencode debug skill
+```
+
+Agents are named `bopen-<plugin>-<agent>`. Commands use
+`/bopen-<plugin>-<command>`; nested paths join with hyphens. Skills retain their
+original names and supporting files. Use OpenCode's `task` tool for delegation
+and `skill` tool for progressive loading. Claude model aliases are not OpenCode
+model IDs: agents inherit the current model. Explicit native user configuration
+can override individual agent settings and disable a bundled MCP server.
+
+## Update and uninstall
+
+Keep the checkout at a stable path. Update it using a fast-forward pull, then
+rerun the same install command and restart OpenCode. Never reset a checkout with
+local changes. To remove selected modules, rerun with `--uninstall --plugin NAME`;
+`--uninstall --all` removes the managed entrypoint. Use the same project/global
+scope used for installation. The source checkout remains yours.
+
+The installer owns only `plugins/bopen.ts` under the chosen OpenCode config
+directory. It preserves existing JSON/JSONC configuration and other plugins;
+modified or unowned entrypoints are rejected. Adding a module preserves existing
+module selections. `opencode/manifest.json` is bOpen compatibility metadata for
+the marketplace, not an OpenCode-standard plugin manifest.
+
+## Compatibility limits
+
+- Core bridges session context, prompt/roster routing, tool safeguards, skill
+  activity and HammerTime. Arbitrary third-party hook registries and proprietary
+  host apps need their own adapters; installation reports these gaps.
+- Guard decisions that request additional confirmation block with an explanation.
+  OpenCode 1.18.20 does not invoke the declared `permission.ask` plugin hook.
+  Existing OpenCode permissions continue to apply; the bridge never grants them.
+- HammerTime uses bounded follow-up turns in a persistent OpenCode session,
+  rather than suppressing the previous answer. It excludes child, failed and
+  cancelled turns, allows one content correction and caps automatic follow-ups.
+  A headless `opencode run` client may return on the first idle event; do not rely
+  on automatic continuation there. Ordinary guards and asset discovery still work.
+- MCP credentials come from environment variables or explicit native configuration.
+  Missing variables leave that server unregistered and produce a warning.
+  Host OAuth setup remains an OpenCode connection step.
+- Source tool names are translated in guidance; host-specific orchestration UI,
+  model aliases and platform tools cannot be reproduced by changing a manifest.
+
+## Verification
+
+```sh
+bun test opencode
+bun opencode/install.ts --all --dry-run
+```
+
+The native API contract was inspected against OpenCode v1.18.20. See the
+[plugin API](https://opencode.ai/docs/plugins/),
+[agents](https://opencode.ai/docs/agents/) and
+[MCP configuration](https://opencode.ai/docs/mcp-servers/).
+
+Native 1.18.20 verification also exercised a real file-read tool against a
+synthetic `.env` using a loopback fake model: the guard blocked before contents
+reached the model. A persistent server test confirmed one HammerTime content
+follow-up, then no further follow-ups after the repeated response. No paid model
+requests were used. Lifecycle unit tests additionally cover errors, cancellation,
+deduplication and the continuation cap.

--- a/opencode/catalog.test.ts
+++ b/opencode/catalog.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadCatalog, applyCatalog, pluginRoots } from './catalog.ts';
+import { install } from './install.ts';
+const temps: string[] = [];
+function fixture(name='demo') {
+  const root = realpathSync(mkdtempSync(join(tmpdir(),'bopen-native-'))); temps.push(root);
+  for (const dir of ['.claude-plugin','agents','commands','skills/demo']) mkdirSync(join(root,dir),{recursive:true});
+  writeFileSync(join(root,'.claude-plugin/plugin.json'),JSON.stringify({name,version:'1.0.0'}));
+  writeFileSync(join(root,'agents/reviewer.md'),'---\ndescription: Review safely\nmodel: opus\ndisallowedTools: [Bash]\n---\nReview the source.');
+  writeFileSync(join(root,'commands/check.md'),'---\ndescription: Check changes\n---\nReview $ARGUMENTS');
+  return root;
+}
+afterEach(()=>{for(const p of temps.splice(0)) rmSync(p,{recursive:true,force:true});});
+test('native catalog provides agents, commands, whole skill folders, and MCP with inherited models',()=>{
+  const root=fixture();
+  writeFileSync(join(root,'.mcp.json'),JSON.stringify({mcpServers:{server:{command:'node',args:['${CLAUDE_PLUGIN_ROOT}/server.js']}}}));
+  const catalog=loadCatalog([root]);
+  expect(catalog.agent['bopen-demo-reviewer'].model).toBeUndefined();
+  expect(catalog.agent['bopen-demo-reviewer'].permission.bash).toBe('deny');
+  expect(catalog.command['bopen-demo-check'].template).toContain('$ARGUMENTS');
+  expect(catalog.skillPaths).toEqual([join(root,'skills')]);
+  expect(catalog.mcp['bopen-demo-server'].command).toEqual(['node',`${root}/server.js`]);
+  const config:any={agent:{'bopen-demo-reviewer':{model:'openai/custom'}},mcp:{'bopen-demo-server':{enabled:false}},permission:{bash:'ask'},skills:{paths:['existing']}};
+  applyCatalog(config,catalog); applyCatalog(config,catalog);
+  expect(config.agent['bopen-demo-reviewer'].model).toBe('openai/custom');
+  expect(config.mcp['bopen-demo-server'].enabled).toBe(false);
+  expect(config.permission).toEqual({bash:'ask'});
+  expect(config.skills.paths).toEqual(['existing',join(root,'skills')]);
+});
+test('missing MCP credentials are reported without inventing secrets',()=>{
+  const root=fixture();
+  writeFileSync(join(root,'.mcp.json'),JSON.stringify({mcpServers:{server:{url:'https://example.com',headers:{Authorization:'${BOPEN_TEST_MISSING_CREDENTIAL_123}'}}}}));
+  const result=loadCatalog([root]);
+  expect(result.mcp).toEqual({}); expect(result.warnings[0]).toContain('Missing environment variable');
+});
+test('installer adds modules, preserves user configuration, detects modified files and removes only its shim',()=>{
+  const root=fixture(); const other=fixture('second'); const target=join(root,'target');
+  mkdirSync(target); writeFileSync(join(target,'opencode.jsonc'),'// keep comments\n{}');
+  install({target,source:root,names:['demo']});
+  const result=install({target,source:other,names:['second']});
+  expect(result.plugins).toEqual(['demo','second']);
+  const shim=join(target,'plugins/bopen.ts'); const original=readFileSync(shim,'utf8');
+  writeFileSync(shim,original+'// user edit');
+  expect(()=>install({target,source:root,names:['demo']})).toThrow('edited');
+  writeFileSync(shim,original);
+  expect(install({target,source:root,names:['demo'],remove:true}).plugins).toEqual(['second']);
+  expect(install({target,source:root,names:['all'],remove:true}).plugins).toEqual([]);
+  expect(readFileSync(join(target,'opencode.jsonc'),'utf8')).toBe('// keep comments\n{}');
+});
+test('scope selection rejects unknown plugins and never silently selects every module',()=>{
+  const root=fixture();
+  expect(pluginRoots(root,['demo'])).toEqual([root]);
+  expect(()=>pluginRoots(root,['missing'])).toThrow('Unknown plugin');
+  expect(()=>pluginRoots(root,[])).toThrow('Select');
+});
+test('unsupported explicit source layouts fail before installation',()=>{
+ const root=fixture(); writeFileSync(join(root,'.claude-plugin/plugin.json'),JSON.stringify({name:'demo',agents:['./elsewhere']}));
+ expect(()=>install({target:join(root,'target'),source:root,names:['demo']})).toThrow('custom agents paths');
+});
+
+test('source tool restrictions use native permissions without granting tools',()=>{
+ const root=fixture();
+ writeFileSync(join(root,'agents/reviewer.md'),'---\ndescription: Read only\ntools: Read, Grep, Glob\ndisallowedTools: [Write, WebSearch]\n---\nReview.');
+ const agent=loadCatalog([root]).agent['bopen-demo-reviewer'];
+ expect(agent.permission.edit).toBe('deny'); expect(agent.permission.bash).toBe('deny');
+ expect(agent.permission.read).toBeUndefined(); expect(agent.permission.websearch).toBe('deny');
+});
+test('uninstall all recovers even after source checkout is removed',()=>{
+ const root=fixture(); const target=fixture('target');
+ install({target,source:root,names:['demo']}); rmSync(root,{recursive:true,force:true});
+ expect(install({target,source:root,names:['all'],remove:true}).plugins).toEqual([]);
+});
+test('default MCP symlinks cannot escape the source',async()=>{
+ const root=fixture(),other=fixture('other');
+ writeFileSync(join(other,'outside.json'),'{}');
+ const {symlinkSync}=await import('node:fs');symlinkSync(join(other,'outside.json'),join(root,'.mcp.json'));
+ expect(()=>loadCatalog([root])).toThrow('escapes');
+});

--- a/opencode/catalog.ts
+++ b/opencode/catalog.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync, realpathSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+export type Catalog = { roots: string[]; agent: Record<string, any>; command: Record<string, any>; skillPaths: string[]; mcp: Record<string, any>; warnings: string[] };
+const validName = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const PRELUDE = `You are running in OpenCode. Use native tools: bash, read, edit, write, glob, grep, webfetch, skill, task, todowrite. Load Skill(name) using the native skill tool (use the skill's unqualified name). Delegate Agent/Task roles using task with the installed bopen-<plugin>-<role> subagent_type. Source Claude model aliases are informational: inherit this session's model unless the user configures an OpenCode override. User permissions still apply. Resolve plugin-relative resources from the source root below.\n`;
+function contained(root: string, path: string): string {
+  const actual = realpathSync(path);
+  if (actual !== root && !actual.startsWith(root + sep)) throw new Error(`Plugin asset escapes its source root: ${path}`);
+  return actual;
+}
+export function markdown(path: string): { meta: Record<string, any>; body: string } {
+  const raw = readFileSync(path, 'utf8');
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) return { meta: {}, body: raw };
+  const meta = Bun.YAML.parse(match[1]);
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) throw new Error(`Invalid frontmatter: ${path}`);
+  return { meta: meta as Record<string, any>, body: raw.slice(match[0].length) };
+}
+export function pluginRoots(source: string, names: string[]): string[] {
+  source = realpathSync(source);
+  const available = [source, ... (existsSync(join(source, 'modules')) ? readdirSync(join(source, 'modules')).sort().map(n => join(source, 'modules', n)) : [])]
+    .filter(p => existsSync(join(p, '.claude-plugin/plugin.json')));
+  const byName = new Map(available.map(p => [JSON.parse(readFileSync(join(p, '.claude-plugin/plugin.json'), 'utf8')).name, p]));
+  const selected = names.includes('all') ? [...byName.keys()] : names;
+  if (!selected.length) throw new Error('Select --plugin <name> or --all.');
+  return [...new Set(selected)].map(name => {
+    const root = byName.get(name);
+    if (!root) throw new Error(`Unknown plugin ${name}; available: ${[...byName.keys()].join(', ')}`);
+    return contained(source, root);
+  });
+}
+function files(root: string, dir: string, extension: string): string[] {
+  if (!existsSync(dir)) return [];
+  contained(root, dir);
+  return readdirSync(dir, { withFileTypes: true }).sort((a,b) => a.name.localeCompare(b.name)).flatMap(e => {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) return files(root, p, extension);
+    if (e.isFile() && e.name.endsWith(extension)) return [contained(root, p)];
+    return [];
+  });
+}
+function substitute(value: string, root: string): string {
+  return value.replaceAll('${CLAUDE_PLUGIN_ROOT}', root).replaceAll('${BOPEN_PLUGIN_ROOT}', root)
+    .replace(/\$\{([A-Z_][A-Z0-9_]*)(?::-([^}]*))?\}/g, (_, key, fallback) => {
+      const result = process.env[key] ?? fallback;
+      if (result === undefined) throw new Error(`Missing environment variable ${key}`);
+      return result;
+    });
+}
+export function loadCatalog(roots: string[]): Catalog {
+  const result: Catalog = { roots, agent: {}, command: {}, skillPaths: [], mcp: {}, warnings: [] };
+  for (const source of roots) {
+    const root = realpathSync(source);
+    const manifest = JSON.parse(readFileSync(join(root, '.claude-plugin/plugin.json'), 'utf8'));
+    const name = manifest.name;
+    if (typeof name !== 'string' || !validName.test(name)) throw new Error(`Invalid plugin name: ${name}`);
+    for (const kind of ['agents', 'commands', 'skills']) {
+      if (manifest[kind] && manifest[kind] !== `./${kind}/` && manifest[kind] !== `./${kind}`) {
+        throw new Error(`${name}: custom ${kind} paths need an explicit adapter; refusing an incomplete install.`);
+      }
+    }
+    const prefix = `bopen-${name}-`;
+    for (const path of files(root, join(root, 'agents'), '.md')) {
+      const {meta,body} = markdown(path);
+      const id = prefix + relative(join(root,'agents'),path).slice(0,-3).split(sep).join('-');
+      if (!meta.description) throw new Error(`Missing agent description: ${path}`);
+      result.agent[id] = { description: String(meta.description), mode: 'subagent', prompt: PRELUDE + `Source root: ${root}\n\n` + body.replaceAll('${CLAUDE_PLUGIN_ROOT}', root) };
+      // Never convert a source allowlist into permission grants. Native user rules win.
+      const denied = typeof meta.disallowedTools === 'string' ? meta.disallowedTools.split(/[ ,]+/) : meta.disallowedTools;
+      const tools: Record<string,string> = { Bash:'bash', Read:'read', Write:'edit', Edit:'edit', MultiEdit:'edit', apply_patch:'edit', Grep:'grep', Glob:'glob', WebSearch:'websearch', WebFetch:'webfetch', Task:'task', Agent:'task', Skill:'skill' };
+      if (Array.isArray(denied)) {
+        const unknown = denied.filter(t => !tools[t]);
+        if (unknown.length) throw new Error(`${id}: cannot preserve disallowed tools ${unknown.join(', ')}`);
+        result.agent[id].permission = Object.fromEntries(denied.map(t => [tools[t], 'deny']));
+      }
+      const allowed = typeof meta.tools === 'string' ? meta.tools.split(/[ ,]+/) : meta.tools;
+      if (Array.isArray(allowed)) {
+        const native = new Set(allowed.map(t => tools[t]).filter(Boolean));
+        for (const key of ['bash','read','edit','glob','grep','webfetch','websearch','task','skill']) {
+          if (!native.has(key)) (result.agent[id].permission ??= {})[key] = 'deny';
+        }
+      }
+    }
+    for (const path of files(root, join(root,'commands'), '.md')) {
+      const {meta,body} = markdown(path);
+      const id = prefix + relative(join(root,'commands'),path).slice(0,-3).split(sep).join('-');
+      result.command[id] = { description: String(meta.description ?? id), template: PRELUDE + `Source root: ${root}\n\n` + body.replaceAll('${CLAUDE_PLUGIN_ROOT}',root) };
+    }
+    if (existsSync(join(root,'skills'))) {
+      const skillRoot = contained(root, join(root,'skills'));
+      for (const file of new Bun.Glob('**/SKILL.md').scanSync({cwd:skillRoot, followSymlinks:true})) contained(root, join(skillRoot,file));
+      result.skillPaths.push(skillRoot);
+    }
+    const mcpPath = manifest.mcpServers;
+    const mcpFile = typeof mcpPath === 'string' ? contained(root, resolve(root,mcpPath)) : join(root,'.mcp.json');
+    const mcps = mcpPath && typeof mcpPath === 'object' ? mcpPath : existsSync(mcpFile) ? JSON.parse(readFileSync(contained(root,mcpFile),'utf8')) : {};
+    for (const [key, raw] of Object.entries(mcps.mcpServers ?? mcps)) {
+      const server = raw as any;
+      const id = prefix + key;
+      try {
+        if (typeof server.command === 'string') {
+          result.mcp[id] = { type:'local', command: [server.command, ...(server.args ?? [])].map((v:string) => substitute(v,root)), environment: Object.fromEntries(Object.entries(server.env ?? {}).map(([k,v])=>[k,substitute(String(v),root)])), enabled:true };
+        } else if (typeof server.url === 'string' && (!server.type || ['http','sse'].includes(server.type))) {
+          result.mcp[id] = { type:'remote', url:substitute(server.url,root), headers:Object.fromEntries(Object.entries(server.headers ?? {}).map(([k,v])=>[k,substitute(String(v),root)])), enabled:true };
+        } else throw new Error('Unsupported MCP transport');
+      } catch (error) { result.warnings.push(`${id}: ${String(error)}. Configure this MCP server in OpenCode to enable it.`); }
+    }
+    if (manifest.hooks && name !== 'core') result.warnings.push(`${name}: custom hook registry is not translated. Only core's reviewed hook bridge is supported.`);
+    if (manifest.apps) result.warnings.push(`${name}: host-specific apps are not portable to OpenCode.`);
+  }
+  return result;
+}
+export function applyCatalog(config: any, catalog: Catalog) {
+  for (const key of ['agent','command','mcp'] as const) {
+    config[key] ??= {};
+    for (const [id, value] of Object.entries(catalog[key])) {
+      // User configuration is authoritative, including explicit disabled entries.
+      config[key][id] = config[key][id] === undefined ? value : { ...value, ...config[key][id] };
+    }
+  }
+  config.skills ??= {};
+  config.skills.paths = [...new Set([...(config.skills.paths ?? []), ...catalog.skillPaths])];
+}

--- a/opencode/hooks.test.ts
+++ b/opencode/hooks.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtemp, writeFile, mkdir, rm, readFile, symlink, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHooks, normalizeTool, type HookRunner } from "./hooks";
+
+async function fixture(run: HookRunner) {
+  const root = await mkdtemp(join(tmpdir(), "bopen-hook-test-"));
+  await mkdir(join(root, "hooks"));
+  for (const script of ["hammertime.py", "damage-control.sh", "pretooluse-bash.sh", "browser-intent.sh", "session-context.sh", "prompt-router.sh", "roster-guard.sh", "skill-activity.sh"]) await writeFile(join(root, "hooks", script), "");
+  const messages: any[] = [
+    { info: { id: "u1", role: "user", agent: "build", model: { providerID: "test", modelID: "test" } }, parts: [{ type: "text", text: "Fix it" }] },
+    { info: { id: "a1", role: "assistant", parentID: "u1", finish: "stop", time: { completed: 1 } }, parts: [{ type: "text", text: "These errors are pre-existing." }] },
+  ];
+  const calls: any[] = [];
+  const client = { session: {
+    get: async () => ({ data: { id: "s1" } }), messages: async () => ({ data: messages }),
+    status: async () => ({ data: {} }), promptAsync: async (value: any) => { calls.push(value); return {}; },
+  } };
+  const hooks = createHooks({ client, directory: root, worktree: root }, [root], { run, coreRoot: root });
+  const idle = () => hooks.event({ event: { type: "session.idle", properties: { sessionID: "s1" } } });
+  return { root, hooks, messages, client, calls, idle, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+describe("native guard adapter", () => {
+  test("ask and failed guard both prevent tool execution", async () => {
+    const f = await fixture(async () => ({ hookSpecificOutput: { permissionDecision: "ask", permissionDecisionReason: "Confirm publish" } }));
+    try { await expect(f.hooks["tool.execute.before"]({ tool: "bash", sessionID: "s1" }, { args: { command: "git push" } })).rejects.toThrow("Confirm publish"); }
+    finally { await f.cleanup(); }
+    const g = await fixture(async () => { throw new Error("runner timed out"); });
+    try { await expect(g.hooks["tool.execute.before"]({ tool: "bash", sessionID: "s1" }, { args: { command: "ls" } })).rejects.toThrow("timed out"); }
+    finally { await g.cleanup(); }
+  });
+  test("patch move destinations and symlinks are checked", async () => {
+    const f = await fixture(async () => ({}));
+    try {
+      await mkdir(join(f.root, "actual")); await symlink(join(f.root, "actual"), join(f.root, "alias"));
+      const data = await normalizeTool("apply_patch", { patchText: "*** Begin Patch\n*** Update File: alias/file\n*** Move to: alias/.env\n*** End Patch" }, f.root);
+      expect(data.tool_input.input).toContain(`*** Add File: ${await realpath(f.root)}/actual/.env`);
+      await expect(normalizeTool("apply_patch", { patchText: "unknown" }, f.root)).rejects.toThrow("recognized");
+    } finally { await f.cleanup(); }
+  });
+});
+
+describe("HammerTime lifecycle", () => {
+  test("normalizes private transcript, preserves model, deduplicates idle, cleans up", async () => {
+    let transcript = "";
+    const f = await fixture(async (_root, script, input) => {
+      if (script !== "hammertime.py") return {};
+      transcript = input.transcript_path;
+      expect(await readFile(transcript, "utf8")).toContain('"type":"assistant"');
+      return { decision: "block", systemMessage: "Fix the errors" };
+    });
+    try {
+      await f.idle(); await f.idle();
+      expect(f.calls.length).toBe(1);
+      expect(f.calls[0].body.model.modelID).toBe("test");
+      expect(await Bun.file(transcript).exists()).toBe(false);
+    } finally { await f.cleanup(); }
+  });
+  test("does not restart aborted or errored sessions", async () => {
+    const f = await fixture(async () => ({ decision: "block", reason: "Continue" }));
+    try {
+      f.messages[1].info.error = { name: "MessageAbortedError" };
+      await f.idle(); expect(f.calls.length).toBe(0);
+      delete f.messages[1].info.error;
+      await f.hooks.event({ event: { type: "session.error", properties: { sessionID: "s1" } } });
+      await f.idle(); expect(f.calls.length).toBe(0);
+    } finally { await f.cleanup(); }
+  });
+  test("cancellation or new user message during evaluation invalidates continuation", async () => {
+    let evaluated!: () => void; let release!: () => void;
+    const started = new Promise<void>(resolve => { evaluated = resolve; });
+    const hold = new Promise<void>(resolve => { release = resolve; });
+    const f = await fixture(async (_root, script) => {
+      if (script !== "hammertime.py") return {};
+      evaluated(); await hold; return { decision: "block", reason: "Continue" };
+    });
+    try {
+      const pending = f.idle(); await started;
+      await f.hooks["chat.message"]({ sessionID: "s1" }, { parts: [{ type: "text", text: "Stop that work" }] });
+      release(); await pending; expect(f.calls.length).toBe(0);
+    } finally { release(); await f.cleanup(); }
+  });
+  test("finite cap survives synthetic chat.message events", async () => {
+    const f = await fixture(async (_root, script) => script === "hammertime.py" ? { decision: "block", reason: "Timer active" } : {});
+    try {
+      for (let index = 0; index < 7; index++) {
+        f.messages[1].info.id = `a${index}`;
+        const count = f.calls.length;
+        await f.idle();
+        const submitted = f.calls.at(-1);
+        if (f.calls.length > count) await f.hooks["chat.message"]({ sessionID: "s1" }, { parts: submitted.body.parts });
+      }
+      expect(f.calls.length).toBe(5);
+    } finally { await f.cleanup(); }
+  });
+});
+
+test('real core shell guard allows harmless input and blocks destructive input without executing it', async()=>{
+ const project=await mkdtemp(join(tmpdir(),'bopen-real-guard-'));
+ await mkdir(join(project,'.opencode'));
+ await writeFile(join(project,'.opencode/bopen-hooks.json'),JSON.stringify({hooks:{bouncer:true,'damage-control':true,'publish-gate':true}}));
+ const hooks=createHooks({client:{},directory:project,worktree:project},[join(import.meta.dir,'..')]);
+ try {
+  await hooks['tool.execute.before']({tool:'bash',sessionID:'guard-test'},{args:{command:'echo hello'}});
+  await expect(hooks['tool.execute.before']({tool:'bash',sessionID:'guard-test'},{args:{command:'rm -rf /'}})).rejects.toThrow();
+  await expect(hooks['tool.execute.before']({tool:'read',sessionID:'guard-test'},{args:{filePath:join(project,'.env')}})).rejects.toThrow();
+ }finally{await hooks.dispose();await rm(project,{recursive:true,force:true});}
+});
+test('matching hook filenames in arbitrary modules are never executed',async()=>{
+ const f=await fixture(async()=>{throw new Error('should not execute')});
+ const hooks=createHooks({client:{},directory:f.root,worktree:f.root},[f.root]);
+ try{await hooks['tool.execute.before']({tool:'bash',sessionID:'s'},{args:{command:'echo hello'}});}
+ finally{await hooks.dispose();await f.cleanup();}
+});

--- a/opencode/hooks.ts
+++ b/opencode/hooks.ts
@@ -1,0 +1,241 @@
+import { existsSync, realpathSync } from "node:fs";
+import { mkdtemp, writeFile, rm, realpath, mkdir, symlink, readFile } from "node:fs/promises";
+import { join, resolve, dirname, basename } from "node:path";
+import { tmpdir, homedir } from "node:os";
+
+type RecordValue = Record<string, any>;
+export type HookRunner = (root: string, script: string, input: RecordValue) => Promise<RecordValue>;
+type Context = { client: any; directory: string; worktree: string };
+const nativeGuidance = "OpenCode: load installed skills with the native skill tool; delegate with task and its subagent_type. Use the installed OpenCode agent/skill names, not Claude tool names. Never infer that a Claude-only tool is available.";
+
+/** Execute only the adapter's hardcoded trusted script names, never manifest commands. */
+function runner(directory: string, environment: () => Promise<Record<string, string>>): HookRunner {
+  return async (root, script, input) => {
+    for (const executable of ["bash", "jq", "python3"]) {
+      if (!Bun.which(executable)) throw new Error(`bOpen hooks require ${executable}; install it before retrying.`);
+    }
+    const child = Bun.spawn([script.endsWith(".py") ? "python3" : "bash", join(root, "hooks", script)], {
+      cwd: directory,
+      env: { ...process.env, ...await environment(), BOPEN_HOOK_RUNTIME: "claude", CLAUDE_PLUGIN_ROOT: root,
+        CLAUDE_PROJECT_DIR: directory, CLAUDE_WORKING_DIR: directory },
+      stdin: new Blob([JSON.stringify(input)]), stdout: "pipe", stderr: "pipe",
+    });
+    const timeout = setTimeout(() => child.kill(), 30_000);
+    try {
+      const [stdout, , code] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited]);
+      if (code !== 0) throw new Error(`bOpen ${script} failed; tool was not approved.`);
+      if (!stdout.trim()) return {};
+      const result = JSON.parse(stdout);
+      if (!result || typeof result !== "object" || Array.isArray(result)) throw new Error(`Invalid ${script} output`);
+      return result;
+    } finally { clearTimeout(timeout); }
+  };
+}
+
+async function canonicalPath(path: string, directory: string): Promise<string> {
+  const absolute = resolve(directory, path);
+  try { return await realpath(absolute); } catch {
+    if (dirname(absolute) === absolute) return absolute;
+    return join(await canonicalPath(dirname(absolute), directory), basename(absolute));
+  }
+}
+
+/** Strict patch-header adaptation includes move destinations and normalized symlink paths. */
+export async function normalizeTool(tool: string, args: RecordValue, directory: string) {
+  const names: Record<string, string> = { bash: "Bash", read: "Read", write: "Write", edit: "Edit", task: "Task", skill: "Skill", webfetch: "WebFetch" };
+  const input = { ...args };
+  if (["read", "write", "edit"].includes(tool)) {
+    if (typeof args.filePath !== "string" || !args.filePath) throw new Error("Missing file path; guard cannot validate this tool.");
+    input.file_path = await canonicalPath(args.filePath, directory);
+  }
+  if (tool === "skill") input.skill = args.name;
+  if (tool === "apply_patch") {
+    if (typeof args.patchText !== "string") throw new Error("Missing patchText; guard cannot validate patch paths.");
+    const headers = args.patchText.split("\n").filter((line: string) => /^\*\*\* (?:Add File:|Update File:|Delete File:|Move to:)/.test(line));
+    if (!headers.length) throw new Error("Patch has no recognized file operations.");
+    const normalized = [];
+    let source: string | undefined;
+    for (const header of headers) {
+      const match = /^\*\*\* (Add File|Update File|Delete File|Move to): (.+)$/.exec(header.trimEnd());
+      if (!match) throw new Error("Malformed patch path.");
+      if (match[1] === "Update File") source = match[2];
+      if (match[1] === "Move to") {
+        if (!source) throw new Error("Patch move has no source path.");
+        normalized.push(`*** Delete File: ${await canonicalPath(source, directory)}`);
+      }
+      normalized.push(`*** ${match[1] === "Move to" ? "Add File" : match[1]}: ${await canonicalPath(match[2], directory)}`);
+    }
+    input.input = normalized.join("\n");
+  }
+  return { tool_name: names[tool] ?? tool, tool_input: input };
+}
+
+type State = { epoch: number; retries: number; blocked: boolean; busy: boolean; seen: Set<string>; context: string; guidance: string };
+export function createHooks({ client, directory }: Context, roots: string[], options: { run?: HookRunner; maxContinuations?: number; coreRoot?: string } = {}) {
+  let runtimeHome: string | undefined;
+  let runtimeEnvironment: Promise<Record<string, string>> | undefined;
+  const pluginNames = new Map<string, string>();
+  const environment = () => runtimeEnvironment ??= (async () => {
+    runtimeHome = await mkdtemp(join(tmpdir(), "bopen-opencode-hooks-"));
+    const cache = join(runtimeHome, "cache");
+    const index = join(runtimeHome, "router-index.json");
+    await mkdir(cache);
+    for (const root of roots) {
+      try {
+        const manifest = JSON.parse(await readFile(join(root, ".claude-plugin/plugin.json"), "utf8"));
+        if (!/^[a-z0-9][a-z0-9-]*$/.test(manifest.name)) continue;
+        pluginNames.set(root, manifest.name);
+        const target = join(cache, manifest.name);
+        await mkdir(target, { recursive: true });
+        await symlink(root, join(target, "installed"));
+      } catch { /* No trusted plugin manifest: do not invent a routing identity. */ }
+    }
+    await writeFile(index, JSON.stringify({ version: 1, entries: [] }), { mode: 0o600 });
+    const builderRoot = roots.find(root => existsSync(join(root, "scripts/build-router-index.py")));
+    if (builderRoot) {
+      const child = Bun.spawn(["python3", join(builderRoot, "scripts/build-router-index.py"), "--cache-root", cache, "--output", index], { stdout: "ignore", stderr: "ignore" });
+      const timeout = setTimeout(() => child.kill(), 10_000);
+      try { await child.exited; } finally { clearTimeout(timeout); }
+    }
+    const projectConfig = join(directory, ".opencode/bopen-hooks.json");
+    const globalConfig = join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "opencode/bopen-hooks.json");
+    const config = process.env.BOPEN_HOOKS_CONFIG ?? (existsSync(projectConfig) ? projectConfig : globalConfig);
+    return { BOPEN_PLUGIN_CACHE_ROOT: cache, BOPEN_ROUTER_INDEX: index,
+      BOPEN_ROUTER_STATE_DIR: join(runtimeHome, "router-state"),
+      ...(existsSync(config) ? { BOPEN_HOOKS_CONFIG: config } : {}) };
+  })();
+  const run = options.run ?? runner(directory, environment);
+  const cap = Math.max(0, Math.min(options.maxContinuations ?? 5, 20));
+  const states = new Map<string, State>();
+  const pendingContinuation = new Map<string, string>();
+  let disposed = false;
+  const state = (id: string) => {
+    if (!states.has(id)) states.set(id, { epoch: 0, retries: 0, blocked: false, busy: false, seen: new Set(), context: "", guidance: "" });
+    return states.get(id)!;
+  };
+  const coreRoot = realpathSync(options.run && options.coreRoot ? options.coreRoot : join(import.meta.dir, ".."));
+  const hasCore = roots.some(root => realpathSync(root) === coreRoot);
+  const selected = (script: string) => {
+    if (!hasCore) return [];
+    const path = realpathSync(join(coreRoot, "hooks", script));
+    if (!path.startsWith(coreRoot + "/hooks/")) throw new Error("Core hook escaped its source directory");
+    return [coreRoot];
+  };
+  const invoke = async (script: string, input: RecordValue, guard = false) => {
+    const results: RecordValue[] = [];
+    for (const root of selected(script)) {
+      try { results.push(await run(root, script, { cwd: directory, ...input })); }
+      catch (error) { if (guard) throw error; }
+    }
+    return results;
+  };
+  const guidance = (results: RecordValue[]) => results.map(r => r.hookSpecificOutput?.additionalContext).filter(v => typeof v === "string").join("\n")
+    .replace(/Skill\((?:[\w-]+:)?([\w-]+)\)/g, 'skill tool with name "$1"')
+    .replace(/subagent_type ([\w-]+):([\w-]+)/g, 'subagent_type bopen-$1-$2');
+  const enforce = (results: RecordValue[]) => {
+    for (const result of results) {
+      const decision = result.hookSpecificOutput?.permissionDecision ?? result.decision;
+      if (decision && !["allow", "approve"].includes(decision)) {
+        throw new Error(result.hookSpecificOutput?.permissionDecisionReason ?? result.reason ?? result.systemMessage ?? "bOpen guard requires explicit user action before this tool can run.");
+      }
+    }
+  };
+  const request = (id: string) => ({ path: { id }, query: { directory } });
+  const unwrap = (response: any) => { if (response.error) throw new Error("OpenCode request failed"); return response.data; };
+
+  const continueIfNeeded = async (id: string) => {
+    const s = state(id);
+    if (disposed || s.busy || s.blocked || s.retries >= cap || !selected("hammertime.py").length) return;
+    s.busy = true;
+    const epoch = s.epoch;
+    let temp: string | undefined;
+    try {
+      const session = unwrap(await client.session.get(request(id)));
+      if (!session || session.parentID) return;
+      const messages = unwrap(await client.session.messages(request(id)));
+      if (!Array.isArray(messages)) return;
+      const last = messages.at(-1);
+      const user = messages.findLast((m: any) => m.info.role === "user");
+      const info = last?.info;
+      if (!user || info?.role !== "assistant" || !info.time?.completed || info.finish !== "stop" || info.error || info.parentID !== user.info.id || s.seen.has(info.id)) return;
+      if (messages.some((m: any) => m.parts.some((p: any) => p.type === "tool" && ["pending", "running"].includes(p.state?.status)))) return;
+      s.seen.add(info.id);
+      // The evaluator must never fall back to an unrelated Claude transcript.
+      temp = await mkdtemp(join(tmpdir(), "bopen-opencode-stop-"));
+      const transcript = join(temp, "transcript.jsonl");
+      const rows = messages.slice(messages.indexOf(user)).map((m: any) => ({ type: m.info.role, message: {
+        role: m.info.role, content: m.parts.filter((p: any) => p.type === "text").map((p: any) => ({ type: "text", text: p.text })),
+      } }));
+      await writeFile(transcript, rows.map((r: any) => JSON.stringify(r)).join("\n"), { mode: 0o600 });
+      const results = await invoke("hammertime.py", { session_id: id, transcript_path: transcript,
+        last_assistant_message: last.parts.filter((p: any) => p.type === "text").map((p: any) => p.text).join("\n"), stop_hook_active: s.retries > 0 });
+      const block = results.find(r => r.decision === "block");
+      if (!block || disposed || s.blocked || s.epoch !== epoch) return;
+      const current = unwrap(await client.session.messages(request(id)));
+      if (current?.at(-1)?.info.id !== info.id || disposed || s.blocked || s.epoch !== epoch) return;
+      const statuses = unwrap(await client.session.status({ query: { directory } }));
+      if (statuses?.[id] && statuses[id].type !== "idle") return;
+      if (disposed || s.blocked || s.epoch !== epoch) return;
+      const text = `[bOpen automatic follow-up ${s.retries + 1}/${cap}]\n${block.systemMessage ?? block.reason}\nRespect the user's original scope and stop requests.`;
+      s.retries++;
+      pendingContinuation.set(id, text);
+      // Never retry ambiguous submission failures: that could duplicate paid work.
+      const response = await client.session.promptAsync({ ...request(id), body: { agent: user.info.agent,
+        model: user.info.model, parts: [{ type: "text", text }] } });
+      if (response.error) s.blocked = true;
+    } catch { s.blocked = true; }
+    finally { s.busy = false; if (temp) await rm(temp, { recursive: true, force: true }); }
+  };
+
+  return {
+    async "chat.message"(input: RecordValue, output: RecordValue) {
+      const s = state(input.sessionID);
+      const expected = pendingContinuation.get(input.sessionID);
+      if (expected && output.parts.some((p: any) => p.type === "text" && p.text === expected)) { pendingContinuation.delete(input.sessionID); return; }
+      pendingContinuation.delete(input.sessionID);
+      s.epoch++; s.retries = 0; s.blocked = false;
+      const prompt = output.parts.filter((p: any) => p.type === "text" && !p.synthetic).map((p: any) => p.text).join("\n");
+      const data = { session_id: input.sessionID, prompt };
+      s.context = guidance(await invoke("session-context.sh", data));
+      s.guidance = guidance([...(await invoke("browser-intent.sh", data)), ...(await invoke("prompt-router.sh", data))]);
+    },
+    async "experimental.chat.system.transform"(input: RecordValue, output: { system: string[] }) {
+      const s = input.sessionID ? state(input.sessionID) : undefined;
+      output.system.push([s?.context, s?.guidance, nativeGuidance].filter(Boolean).join("\n"));
+    },
+    async "tool.execute.before"(input: RecordValue, output: { args: RecordValue }) {
+      const tool = input.tool;
+      const data = { ...(await normalizeTool(tool, output.args, directory)), session_id: input.sessionID };
+      if (tool === "task") {
+        if (data.tool_input.subagent_type === "general") data.tool_input.subagent_type = "general-purpose";
+        if (data.tool_input.subagent_type === "explore") data.tool_input.subagent_type = "Explore";
+        for (const name of pluginNames.values()) {
+          const prefix = `bopen-${name}-`;
+          if (data.tool_input.subagent_type?.startsWith(prefix)) data.tool_input.subagent_type = `${name}:${data.tool_input.subagent_type.slice(prefix.length)}`;
+        }
+      }
+      if (tool === "bash") enforce(await invoke("pretooluse-bash.sh", data, true));
+      if (["read", "write", "edit", "apply_patch"].includes(tool)) enforce(await invoke("damage-control.sh", data, true));
+      if (tool === "task") { const results = await invoke("roster-guard.sh", data, true); enforce(results); state(input.sessionID).guidance += "\n" + guidance(results); }
+      if (tool === "skill") await invoke("skill-activity.sh", data);
+    },
+    async "experimental.session.compacting"(input: RecordValue, output: { context: string[] }) {
+      output.context.push(nativeGuidance);
+      state(input.sessionID).context = "";
+    },
+    async event({ event }: { event: RecordValue }) {
+      const id = event.properties?.sessionID ?? event.properties?.info?.id;
+      if (!id) return;
+      if (["session.error", "session.deleted"].includes(event.type)) {
+        const s = state(id); s.blocked = true; s.epoch++;
+      }
+      if (event.type === "session.idle") await continueIfNeeded(id);
+    },
+    async dispose() {
+      disposed = true;
+      for (const s of states.values()) { s.blocked = true; s.epoch++; }
+      await runtimeEnvironment?.catch(() => {});
+      if (runtimeHome) await rm(runtimeHome, { recursive: true, force: true });
+    },
+  };
+}

--- a/opencode/index.ts
+++ b/opencode/index.ts
@@ -1,0 +1,16 @@
+import { loadCatalog, applyCatalog } from './catalog.ts';
+import { createHooks } from './hooks.ts';
+
+// Imported by the one installer-owned entrypoint, never copied into a loader directory.
+export function createBopenPlugin(roots: string[]) {
+  return async (input: any) => {
+    const catalog = loadCatalog(roots);
+    for (const warning of catalog.warnings) {
+      await input.client.app.log({body:{service:'bopen',level:'warn',message:warning}});
+    }
+    return {
+      ...await createHooks(input, roots),
+      config: async (config: any) => applyCatalog(config, catalog),
+    };
+  };
+}

--- a/opencode/install.ts
+++ b/opencode/install.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+import { existsSync, readFileSync, realpathSync, mkdirSync, renameSync, unlinkSync, writeFileSync, lstatSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import { loadCatalog, pluginRoots } from './catalog.ts';
+
+type State = { schema: 1; adapter: string; roots: string[] };
+const marker = '// bopen-managed: ';
+export function render(state: State): string {
+  return marker + JSON.stringify(state) + '\n' +
+    `import { createBopenPlugin } from ${JSON.stringify(pathToFileURL(join(state.adapter,'index.ts')).href)};\n` +
+    `export default createBopenPlugin(${JSON.stringify(state.roots)});\n`;
+}
+export function install(options: { target: string; source: string; names: string[]; remove?: boolean; dryRun?: boolean }) {
+  const target = resolve(options.target);
+  const shim = join(target,'plugins','bopen.ts');
+  let previous: State | undefined;
+  if (existsSync(shim)) {
+    if (lstatSync(shim).isSymbolicLink()) throw new Error(`Refusing to replace a symlink: ${shim}`);
+    const raw = readFileSync(shim,'utf8');
+    if (!raw.startsWith(marker)) throw new Error(`Existing plugin is not installer-owned: ${shim}`);
+    previous = JSON.parse(raw.split('\n')[0].slice(marker.length));
+    if (!previous || previous.schema !== 1 || !Array.isArray(previous.roots) || typeof previous.adapter !== 'string' || render(previous) !== raw) throw new Error(`Managed plugin was edited; preserve your changes before reinstalling: ${shim}`);
+  }
+  const pluginName = (root: string) => JSON.parse(readFileSync(join(root,'.claude-plugin/plugin.json'),'utf8')).name as string;
+  const selected = options.remove ? [] : pluginRoots(options.source, options.names);
+  const replace = new Set(options.remove ? options.names : selected.map(pluginName));
+  const roots = options.remove && replace.has('all') ? [] : [...(previous?.roots ?? []).filter(root => !replace.has(pluginName(root)) && !(options.remove && replace.has('all'))), ...selected];
+  const catalog = loadCatalog(roots); // Validate everything before writing anything.
+  const state: State = { schema:1, adapter:realpathSync(import.meta.dir), roots };
+  if (!options.dryRun) {
+    if (!roots.length) { if (previous) unlinkSync(shim); }
+    else {
+      mkdirSync(dirname(shim),{recursive:true});
+      const tmp = shim + `.tmp-${process.pid}`;
+      try { writeFileSync(tmp,render(state),{flag:'wx', mode:0o600}); renameSync(tmp,shim); }
+      finally { if (existsSync(tmp)) unlinkSync(tmp); }
+    }
+  }
+  return { entrypoint:shim, plugins:roots.map(pluginName), agents:Object.keys(catalog.agent), commands:Object.keys(catalog.command), skillPaths:catalog.skillPaths, mcp:Object.keys(catalog.mcp), warnings:catalog.warnings, dryRun:!!options.dryRun };
+}
+if (import.meta.main) {
+  try {
+    const { values } = parseArgs({ args:process.argv.slice(2), options:{
+      source:{type:'string'}, plugin:{type:'string',multiple:true}, all:{type:'boolean'},
+      project:{type:'string'}, global:{type:'boolean'}, uninstall:{type:'boolean'},
+      'dry-run':{type:'boolean'}, help:{type:'boolean'},
+    }, strict:true });
+    if (values.help) {
+      console.log('bun opencode/install.ts [--source CHECKOUT] (--plugin NAME ... | --all) [--project PATH | --global] [--uninstall] [--dry-run]\nDefault scope: current project. Keeps your existing OpenCode configuration. Requires a persistent source checkout, Bun, Python 3, bash and jq for core hooks. Restart OpenCode after changes.');
+    } else {
+      if (values.global && values.project) throw new Error('Choose --project or --global, not both.');
+      const names = values.all ? ['all'] : values.plugin ?? [];
+      if (!names.length) throw new Error('Select --plugin NAME or --all.');
+      const target = values.global ? join(process.env.XDG_CONFIG_HOME ?? join(homedir(),'.config'),'opencode') : join(resolve(values.project ?? process.cwd()),'.opencode');
+      console.log(JSON.stringify(install({target, source:resolve(values.source ?? join(import.meta.dir,'..')), names, remove:values.uninstall, dryRun:values['dry-run']}),null,2));
+    }
+  } catch (error) { console.error(String(error)); process.exitCode = 1; }
+}

--- a/opencode/manifest.json
+++ b/opencode/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "adapter": "bopen-suite",
+  "plugin": "core"
+}

--- a/scripts/test-opencode-install.sh
+++ b/scripts/test-opencode-install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+command -v opencode >/dev/null
+command -v bun >/dev/null
+validation_root="$(mktemp -d)"
+trap 'rm -rf "$validation_root"' EXIT
+mkdir -p "$validation_root/project" "$validation_root/home"
+export HOME="$validation_root/home"
+export XDG_CONFIG_HOME="$validation_root/config"
+export XDG_DATA_HOME="$validation_root/data"
+export XDG_CACHE_HOME="$validation_root/cache"
+export XDG_STATE_HOME="$validation_root/state"
+bun "$repo_root/opencode/install.ts" --all --project "$validation_root/project" > "$validation_root/inventory.json"
+cd "$validation_root/project"
+# Regular output files avoid the CLI exiting before large pipe writes flush.
+opencode debug config > "$validation_root/config.json"
+opencode debug skill > "$validation_root/skills.json"
+opencode debug agent bopen-core-front-desk > "$validation_root/agent.json"
+python3 - "$validation_root" <<'PY'
+import json,sys
+from pathlib import Path
+root=Path(sys.argv[1]); inventory=json.loads((root/'inventory.json').read_text()); config=json.loads((root/'config.json').read_text()); skills=json.loads((root/'skills.json').read_text()); agent=json.loads((root/'agent.json').read_text())
+assert set(inventory['agents']) <= set(config['agent'])
+assert set(inventory['commands']) <= set(config['command'])
+assert set(inventory['skillPaths']) <= set(config['skills']['paths'])
+assert any(s['name']=='hammertime' for s in skills)
+assert 'OpenCode' in agent['prompt']
+print(f"Native OpenCode discovery passed: {len(inventory['agents'])} agents, {len(inventory['commands'])} commands, {len(skills)} skills")
+PY

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-version: 1.0.4
+version: 1.0.5
 description: >-
   Audit which bOpen plugins, CLIs, env keys, third-party skills, agents, and hooks are installed
   across the harness, then emit a runtime-tailored instruction plan; it installs nothing itself.
@@ -106,13 +106,26 @@ detection still works. Never fabricate a version number to fill the gap.
 |---|---|---|---|
 | Claude Code | `claude plugin install x@marketplace` | bundled with plugin | `CLAUDECODE` env |
 | Codex CLI | `codex plugin add` + marketplace | `codex-agent-setup` scripts | Codex session env/paths |
-| OpenCode | reads `.claude/skills/` + Claude Code agent `.md` natively | native parse of CC agent files | `$OPENCODE` / `$AGENT` env, `opencode.json` |
+| OpenCode | native bOpen adapter from a persistent prompts checkout | namespaced agents and commands, native skill paths, supported MCP and core hook bridge | `$OPENCODE` / `$AGENT` env, `opencode.json` |
 | Grok Build | zero-config Claude Code compat (marketplaces, plugins, skills, agents, hooks, CLAUDE.md) | native (CC compat) | `~/.grok/config.toml` + `grok` on PATH |
 | Hermes | SKILL.md supported but installs to `~/.hermes/skills/`, never the repo tree | not deliverable — no CC agent-file parsing | `hermes` on PATH + `~/.hermes/` present |
 | Pi / unknown | no skill-discovery mechanism | n/a | none — generic fallback |
 
-For OpenCode and Grok Build the plan mostly verifies discovery rather than
-installing anything new (Grok: `grok inspect` shows exactly what it found).
+OpenCode uses `bun <prompts-checkout>/opencode/install.ts --plugin NAME --global`.
+The generated plan keeps the source at `${XDG_DATA_HOME:-$HOME/.local/share}/bopen/opencode-source`,
+clones it once, and updates with a clean working tree and fast-forward merge.
+Repeat `--plugin` for selected plugins; `--all` is only for an explicit full-suite request.
+For project scope, omit `--global` in the target project or pass `--project PATH`.
+Use the same scope and selection with `--uninstall` to remove only managed entries.
+An existing Claude installation does not prove anything is installed in OpenCode.
+Verify the native shim and inspect `opencode debug config`, `opencode debug skill`,
+and `opencode debug agent <exact-name>` without making model requests.
+Namespaced agents and commands use `bopen-<plugin>-<name>`.
+The adapter supports the core source and modules shipped in the prompts repository;
+third-party catalog entries need their own supported installation path. Report
+unsupported components from the adapter's capability report instead of claiming parity.
+Restart OpenCode after changing the installation. Grok Build continues to verify
+Claude-compatible discovery with `grok inspect`.
 Hermes gets its own dialect since it can't consume agent `.md` files and
 caches skill content as injected user messages — the plan calls that out
 rather than assuming parity. Unrecognized runtimes get the generic tier:

--- a/skills/setup/playground/src/components/setup/PluginTab.tsx
+++ b/skills/setup/playground/src/components/setup/PluginTab.tsx
@@ -79,13 +79,14 @@ function PluginInstallSection({
 	onToggleUninstallPlugin: () => void
 }) {
 	const installedForRuntime =
-		selectedRuntime === "codex" ? plugin.installedCodex !== null : plugin.installedClaude !== null
-	const uninstallCommand = installedForRuntime
+		selectedRuntime === "opencode" ? false : selectedRuntime === "codex" ? plugin.installedCodex !== null : plugin.installedClaude !== null
+	const uninstallCommand = installedForRuntime || selectedRuntime === "opencode"
 		? pluginUninstallCommand(plugin.name, selectedRuntime, plugin.marketplace)
 		: null
-	const rows: Array<["claude" | "codex", string | null]> = [
+	const rows: Array<["claude" | "codex" | "opencode", string | null]> = [
 		["claude", plugin.installedClaude],
 		["codex", plugin.installedCodex],
+		...(selectedRuntime === "opencode" ? [["opencode", null] as ["opencode", null]] : []),
 	]
 
 	return (
@@ -104,7 +105,9 @@ function PluginInstallSection({
 					const applicable = runtime === selectedRuntime
 					const checked = installed || (applicable && selection.installPlugin)
 					const inert = installed || !applicable
-					const detail = installed
+					const detail = runtime === "opencode"
+						? "native installation not audited — select to install or update and verify"
+						: installed
 						? `v${version}`
 						: `not installed${applicable ? " — check the box to include install in the plan" : " — not the active plan runtime"}`
 					const cmd = !installed

--- a/skills/setup/playground/src/lib/links.ts
+++ b/skills/setup/playground/src/lib/links.ts
@@ -35,8 +35,13 @@ export function pluginUninstallCommand(
 	runtime: string,
 	marketplace: string | null,
 ): string | null {
+	if (runtime === "opencode") {
+		return marketplace === "b-open-io" && /^[a-z0-9][a-z0-9-]*$/.test(name)
+			? `bun "\${XDG_DATA_HOME:-$HOME/.local/share}/bopen/opencode-source/opencode/install.ts" --plugin ${name} --global --uninstall`
+			: null
+	}
 	if (runtime === "codex") return `codex plugin remove ${name}`
-	if (runtime === "claude" || runtime === "opencode" || runtime === "grok") {
+	if (runtime === "claude" || runtime === "grok") {
 		return marketplace ? `claude plugin uninstall ${name}@${marketplace}` : null
 	}
 	return null

--- a/skills/setup/playground/src/lib/pack-dependencies.test.ts
+++ b/skills/setup/playground/src/lib/pack-dependencies.test.ts
@@ -91,3 +91,10 @@ describe("runtime install commands", () => {
 		expect(installCommandForRuntime(portable, "codex")).toBe("npx skills add react-doctor")
 	})
 })
+
+
+test("OpenCode does not inherit Claude plugin status or install commands", () => {
+  const dependencies = diffPackDependencies(pack, state, "opencode")
+  expect(dependencies.find((item) => item.name === "core")?.installed).toBe(false)
+  expect(dependencies.find((item) => item.name === "core")?.installCommand).toBe("")
+})

--- a/skills/setup/playground/src/lib/pack-dependencies.ts
+++ b/skills/setup/playground/src/lib/pack-dependencies.ts
@@ -18,8 +18,9 @@ function installedVersion(
 
 	const installed = state.plugins.find((candidate) => candidate.name === plugin.name)
 	if (!installed) return null
+	if (runtime === "opencode") return null // Claude/Codex caches are not native installation evidence.
 	if (runtime === "codex") return installed.installedCodex
-	if (runtime === "claude" || runtime === "opencode" || runtime === "grok") {
+	if (runtime === "claude" || runtime === "grok") {
 		return installed.installedClaude
 	}
 	return installed.installedCodex ?? installed.installedClaude
@@ -31,6 +32,11 @@ function installedVersion(
 export function installCommandForRuntime(plugin: PackPlugin, runtime: Runtime): string {
 	if (plugin.marketplace === "portable-skill") {
 		return plugin.install.replace(/\s+\(source pinned in the pack setup manifest\)$/, "")
+	}
+	if (runtime === "opencode") {
+		// Pack execution is only supported for Claude, Codex and Grok; never
+		// leak its Claude install hint into an OpenCode copy button.
+		return ""
 	}
 	if (runtime === "codex") {
 		return `codex plugin marketplace upgrade\ncodex plugin add ${plugin.name}@${plugin.marketplace}`

--- a/skills/setup/scripts/emitter.test.ts
+++ b/skills/setup/scripts/emitter.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { emitPlan } from "./emitter";
 
 function makeState(overrides: Record<string, unknown> = {}, plugins: any[] = []): any {
@@ -421,4 +424,82 @@ describe("plugin removals", () => {
     });
     expect(plan).not.toContain("## Plugin removals");
   });
+});
+
+
+describe("OpenCode native plans", () => {
+  const selection = { name: "core", installPlugin: true, uninstallPlugin: false, checks: [], hooks: {} };
+
+  test("installed Claude never suppresses a native install or verifies it", () => {
+    const plan = emitPlan(makeState({}, [makePlugin({ installedClaude: "9.9.9", marketplaceVersion: "9.9.9" })]), {
+      runtime: "opencode", plugins: [selection],
+    });
+    expect(plan).toContain('bun "$BOPEN_SOURCE/opencode/install.ts" --plugin core --global');
+    expect(plan).toContain("git -C \"$BOPEN_SOURCE\" merge --ff-only origin/HEAD");
+    expect(plan).not.toContain("claude plugin");
+    expect(plan).not.toContain("--all");
+    expect(plan).toContain("opencode debug config");
+    expect(plan).toContain("opencode debug skill");
+    for (const match of plan.matchAll(/```sh\n([\s\S]*?)\n```/g)) {
+      const result = Bun.spawnSync(["sh", "-n"], { stdin: Buffer.from(match[1]) });
+      expect(result.exitCode).toBe(0);
+    }
+  });
+
+  test("removal works independently of Claude installation state", () => {
+    const plan = emitPlan(makeState({}, [makePlugin()]), {
+      runtime: "opencode", plugins: [{ ...selection, installPlugin: false, uninstallPlugin: true }],
+    });
+    expect(plan).toContain("--plugin core --global --uninstall");
+    expect(plan).not.toContain("claude plugin");
+  });
+
+  test("unsupported marketplaces do not get an invented native install", () => {
+    const plan = emitPlan(makeState({}, [makePlugin({ marketplace: "third-party" })]), {
+      runtime: "opencode", plugins: [selection],
+    });
+    expect(plan).toContain("native OpenCode delivery unavailable");
+    expect(plan).not.toContain("--plugin core");
+    expect(plan).not.toContain("claude plugin install");
+  });
+});
+
+
+test("native verification checks selected roots, including removal of the last plugin", () => {
+  const temp = mkdtempSync(join(tmpdir(), "bopen-setup-native-"));
+  try {
+    const root = join(temp, "data/bopen/opencode-source");
+    const shim = join(temp, "config/opencode/plugins/bopen.ts");
+    mkdirSync(join(temp, "config/opencode/plugins"), { recursive: true });
+    const run = (remove: boolean) => {
+      const plan = emitPlan(makeState({}, [makePlugin()]), {
+        runtime: "opencode", plugins: [{ name: "core", installPlugin: !remove, uninstallPlugin: remove, checks: [], hooks: {} }],
+      });
+      const block = [...plan.matchAll(/```sh\n([\s\S]*?)\n```/g)].find((match) => match[1].includes("bun -e"))![1];
+      // Run only the registry verification, leaving real CLI discovery to integration tests.
+      return Bun.spawnSync(["sh", "-ec", block.split("\nopencode debug")[0]], {
+        env: { ...process.env, XDG_CONFIG_HOME: join(temp, "config"), XDG_DATA_HOME: join(temp, "data") },
+      }).exitCode;
+    };
+    expect(run(false)).not.toBe(0);
+    writeFileSync(shim, `// bopen-managed: ${JSON.stringify({ schema: 1, adapter: root + "/opencode", roots: [root] })}\nexport default {};\n`);
+    expect(run(false)).toBe(0);
+    expect(run(true)).not.toBe(0);
+    rmSync(shim);
+    expect(run(true)).toBe(0);
+  } finally { rmSync(temp, { recursive: true, force: true }); }
+});
+
+test('OpenCode hook-state script updates the nested hook map and preserves other settings', async()=>{
+ const project=mkdtempSync(join(tmpdir(),'bopen-hook-config-'));
+ try {
+  mkdirSync(join(project,'.opencode'));
+  writeFileSync(join(project,'.opencode/bopen-hooks.json'),JSON.stringify({note:'keep',hooks:{bouncer:false,'publish-gate':false}}));
+  const plan=emitPlan(makeState({},[makePlugin()]),{runtime:'opencode',plugins:[{name:'core',installPlugin:false,uninstallPlugin:false,checks:[],hooks:{bouncer:true,hammertime:false}}]});
+  const block=[...plan.matchAll(/```sh\n([\s\S]*?)\n```/g)].find(m=>m[1].startsWith("python3 - <<'PY'"));
+  expect(block).toBeDefined();
+  const result=Bun.spawnSync(['sh','-c',block![1]],{cwd:project});expect(result.exitCode).toBe(0);
+  const config=await Bun.file(join(project,'.opencode/bopen-hooks.json')).json();
+  expect(config).toEqual({note:'keep',hooks:{bouncer:true,'publish-gate':false,hammertime:false}});
+ }finally{rmSync(project,{recursive:true,force:true});}
 });

--- a/skills/setup/scripts/emitter.ts
+++ b/skills/setup/scripts/emitter.ts
@@ -12,6 +12,61 @@ import { validatePackRuntime } from "./pack";
 import { RUNTIMES, type Runtime } from "./runtimes";
 
 const MARKETPLACE = "b-open-io";
+const OPENCODE_SOURCE = '${XDG_DATA_HOME:-$HOME/.local/share}/bopen/opencode-source';
+const OPENCODE_CONFIG = '${XDG_CONFIG_HOME:-$HOME/.config}/opencode';
+
+function openCodeSource(): string {
+  return `BOPEN_SOURCE="${OPENCODE_SOURCE}"`;
+}
+
+function openCodeBootstrap(): string {
+  return [
+    "set -e",
+    openCodeSource(),
+    'if [ ! -e "$BOPEN_SOURCE" ]; then',
+    '  mkdir -p "$(dirname "$BOPEN_SOURCE")"',
+    '  git clone https://github.com/b-open-io/prompts.git "$BOPEN_SOURCE"',
+    "else",
+    '  test -d "$BOPEN_SOURCE/.git"',
+    '  test "$(git -C "$BOPEN_SOURCE" remote get-url origin)" = "https://github.com/b-open-io/prompts.git"',
+    '  test -z "$(git -C "$BOPEN_SOURCE" status --porcelain)"',
+    '  git -C "$BOPEN_SOURCE" fetch origin',
+    '  git -C "$BOPEN_SOURCE" merge --ff-only origin/HEAD',
+    "fi",
+    'test -f "$BOPEN_SOURCE/opencode/install.ts"',
+  ].join("\n");
+}
+
+function openCodeSelection(plugin: PluginState): boolean {
+  return plugin.marketplace === MARKETPLACE && /^[a-z0-9][a-z0-9-]*$/.test(plugin.name);
+}
+
+
+function openCodeVerify(pluginName: string, present: boolean): string {
+  const suffix = pluginName === "core" ? "" : `/modules/${pluginName}`;
+  // The shim metadata is the installer's sole registry. Verify selection as
+  // well as shim existence; debug inspection then checks runtime discovery.
+  const script = [
+    'const fs = require("node:fs");',
+    'const [shim, root, expected] = process.argv.slice(1);',
+    'let roots = [];',
+    'if (fs.existsSync(shim)) {',
+    'const line = fs.readFileSync(shim, "utf8").split("\\n")[0];',
+    'if (!line.startsWith("// bopen-managed: ")) process.exit(1);',
+    'const state = JSON.parse(line.slice("// bopen-managed: ".length));',
+    'if (state.schema !== 1 || !Array.isArray(state.roots)) process.exit(1);',
+    'roots = state.roots;',
+    '}',
+    'if (roots.includes(root) !== (expected === "yes")) process.exit(1);',
+  ].join(" ");
+  return [
+    "set -e",
+    openCodeSource(),
+    `bun -e '${script}' "${OPENCODE_CONFIG}/plugins/bopen.ts" "$BOPEN_SOURCE${suffix}" ${present ? "yes" : "no"}`,
+    "opencode debug config",
+    "opencode debug skill",
+  ].join("\n");
+}
 
 function findPlugin(state: HarnessState, name: string): PluginState | undefined {
   return state.plugins.find((plugin) => plugin.name === name);
@@ -75,15 +130,20 @@ function pluginCacheRoot(runtime: Runtime, plugin: PluginState): string | null {
   if (runtime === "codex") {
     return `$HOME/.codex/plugins/cache/${plugin.marketplace}/${plugin.name}`;
   }
-  if (runtime === "claude" || runtime === "opencode" || runtime === "grok") {
+  if (runtime === "claude" || runtime === "grok") {
     return `$HOME/.claude/plugins/cache/${plugin.marketplace}/${plugin.name}`;
   }
   return null;
 }
 
 function inPluginRoot(runtime: Runtime, plugin: PluginState, command: string): string | null {
-  const cacheRoot = pluginCacheRoot(runtime, plugin);
   const portable = portableCommand(command);
+  if (runtime === "opencode") {
+    if (!openCodeSelection(plugin) || !portable) return null;
+    const suffix = plugin.name === "core" ? "" : `/modules/${plugin.name}`;
+    return [openCodeSource(), `cd "$BOPEN_SOURCE${suffix}"`, portable].join("\n");
+  }
+  const cacheRoot = pluginCacheRoot(runtime, plugin);
   if (!cacheRoot || !portable) return null;
   return [
     `CACHE_ROOT="${cacheRoot}"`,
@@ -95,7 +155,10 @@ function inPluginRoot(runtime: Runtime, plugin: PluginState, command: string): s
 }
 
 function pluginVerify(runtime: Runtime, pluginName: string): string {
-  if (runtime === "claude" || runtime === "opencode") {
+  if (runtime === "opencode") {
+    return openCodeVerify(pluginName, true);
+  }
+  if (runtime === "claude") {
     return `claude plugin list | grep -F "${pluginName}"`;
   }
   if (runtime === "codex") {
@@ -118,7 +181,21 @@ function buildPluginsSection(
     const plugin = findPlugin(state, selection.name);
     if (!plugin) continue;
 
-    if (runtime === "claude" || runtime === "opencode") {
+    if (runtime === "opencode") {
+      if (!openCodeSelection(plugin)) {
+        blocks.push(`### ${plugin.name}: native OpenCode delivery unavailable\n\nThis selection has no supported bOpen source adapter. Report it as not applicable; do not install a Claude plugin as a substitute.`);
+        continue;
+      }
+      blocks.push(action(
+        `${plugin.name}: install or update the native OpenCode plugin`,
+        `${openCodeBootstrap()}\nbun "$BOPEN_SOURCE/opencode/install.ts" --plugin ${plugin.name} --global`,
+        pluginVerify(runtime, plugin.name),
+        `The adapter installs only the selected source plugin. If ${plugin.name} is not present in this repository, stop this item as unsupported. Inspect the emitted capability report and confirm its namespaced agents, commands, skills and supported MCP entries in the debug output; a Claude cache is not installation evidence. Restart OpenCode after installation.`,
+      ));
+      continue;
+    }
+
+    if (runtime === "claude") {
       const command = !plugin.marketplace
         ? null
         : plugin.installedClaude === null
@@ -132,9 +209,7 @@ function buildPluginsSection(
             `${plugin.name}: install or update the plugin`,
             command,
             pluginVerify(runtime, plugin.name),
-            runtime === "opencode"
-              ? "OpenCode consumes the Claude Code-compatible plugin installation."
-              : undefined,
+            undefined,
           ),
         );
       }
@@ -224,6 +299,19 @@ function buildRemovalsSection(
     if (!selection.uninstallPlugin) continue;
     const plugin = findPlugin(state, selection.name);
     if (!plugin) continue;
+    if (runtime === "opencode") {
+      if (!openCodeSelection(plugin)) {
+        blocks.push(`### ${plugin.name}: removal unavailable\n\nThis plugin has no supported bOpen OpenCode adapter. Inspect its actual installation mechanism before removing it.`);
+        continue;
+      }
+      blocks.push(action(
+        `${plugin.name}: remove the native OpenCode plugin`,
+        `set -e\n${openCodeSource()}\ntest -f "$BOPEN_SOURCE/opencode/install.ts"\nbun "$BOPEN_SOURCE/opencode/install.ts" --plugin ${plugin.name} --global --uninstall`,
+        openCodeVerify(plugin.name, false),
+        `Confirm the adapter's managed ${plugin.name} source and its namespaced capabilities are absent. Other selected plugins and user configuration remain installed. Restart OpenCode after removal.`,
+      ));
+      continue;
+    }
     if (runtime === "codex") {
       if (plugin.installedCodex === null) continue;
       blocks.push(
@@ -235,7 +323,7 @@ function buildRemovalsSection(
       );
       continue;
     }
-    if (runtime === "claude" || runtime === "opencode" || runtime === "grok") {
+    if (runtime === "claude" || runtime === "grok") {
       if (plugin.installedClaude === null) continue;
       if (!plugin.marketplace) {
         blocks.push(
@@ -311,10 +399,14 @@ function buildAgentsSection(
 ): string[] {
   const blocks: string[] = [];
   for (const { plugin, check } of selectedChecks(state, selections, "codex-agents")) {
+    if (runtime === "opencode") {
+      blocks.push(`### ${plugin.name}: native agent delivery\n\nAgents require this plugin's native OpenCode adapter installation above; if it was not selected, inspect the existing installation first. Use \`opencode debug config\` to list its bopen-${plugin.name}- agent names, then run \`opencode debug agent <exact-name>\` for the agents you need. Missing agents are a failed delivery check, not a successful Claude cache discovery.`);
+      continue;
+    }
     if (runtime !== "codex") {
       blocks.push(
         `### ${plugin.name}: agent delivery\n\nNo command is required: ${
-          runtime === "claude" || runtime === "opencode" || runtime === "grok"
+          runtime === "claude" || runtime === "grok"
             ? "agents are bundled with the compatible plugin installation."
             : "agent files are not deliverable on this runtime. Record this item as not applicable."
         }`,
@@ -392,6 +484,31 @@ function buildHooksSection(state: HarnessState, selections: PlanSelections): str
     if (!plugin) continue;
     const desiredEntries = Object.entries(selection.hooks ?? {});
     if (desiredEntries.length === 0) continue;
+
+    if (selections.runtime === "opencode") {
+      const encoded = Buffer.from(JSON.stringify(Object.fromEntries(desiredEntries))).toString("base64");
+      blocks.push(action(
+        `${plugin.name}: apply the selected OpenCode hook states`,
+        [
+          "python3 - <<'PY'",
+          "import base64, json",
+          "from pathlib import Path",
+          'path = Path(".opencode/bopen-hooks.json")',
+          'if path.is_symlink(): raise ValueError("Refusing a symlinked hook config")',
+          'current = json.loads(path.read_text()) if path.exists() else {}',
+          'if not isinstance(current, dict): raise ValueError("Hook config must be an object")',
+          'hooks = current.setdefault("hooks", {})',
+          'if not isinstance(hooks, dict): raise ValueError("hooks must be an object")',
+          `hooks.update(json.loads(base64.b64decode("${encoded}")))`,
+          'path.parent.mkdir(parents=True, exist_ok=True)',
+          'path.write_text(json.dumps(current, indent=2) + "\\n")',
+          "PY",
+        ].join("\n"),
+        'python3 -m json.tool .opencode/bopen-hooks.json >/dev/null',
+        "Run in the target OpenCode project. Hook configuration is ask-tier: confirm with the user before writing this file. Existing unrelated keys are preserved.",
+      ));
+      continue;
+    }
 
     const currentByName = new Map(plugin.hooks.map((hook) => [hook.name, hook.enabled]));
     if (!desiredEntries.some(([name, desired]) => currentByName.get(name) !== desired)) continue;
@@ -478,7 +595,7 @@ function finalRuntimeVerification(runtime: Runtime): string {
   if (runtime === "claude") return "claude plugin list";
   if (runtime === "codex") return "codex plugin list";
   if (runtime === "grok") return "grok inspect";
-  if (runtime === "opencode") return "opencode --version\nclaude plugin list";
+  if (runtime === "opencode") return "opencode --version\nopencode debug config\nopencode debug skill";
   if (runtime === "hermes") return "hermes --version\nnpx skills list";
   return "npx skills list";
 }


### PR DESCRIPTION
OpenCode now loads the bOpen suite as a native plugin: canonical agents, commands, complete skill directories, supported MCP definitions, and the core hook bridge. Installation selects modules or the whole suite, preserves existing configuration, and owns one removable entrypoint. Core is 1.1.161; each module receives a patch bump and an explicit support declaration.

HammerTime uses bounded follow-up turns in persistent OpenCode sessions. Its source commands now resolve the shared state path on all harnesses. Additional-confirmation guard decisions block rather than grant access; host-specific apps, arbitrary hook registries, repo-freshness/browser-fetch adapters and headless Stop parity remain outside this bridge.

Validation:
- 41 adapter/setup tests; 381 existing cross-harness hook checks.
- Native OpenCode 1.18.20 discovers 30 agents, 14 commands and 85 suite skills (plus its built-in skill).
- Live loopback fake-provider test: actual read tool blocked a synthetic .env before content reached the model; persistent server issued exactly one HammerTime correction, then stopped.
- Manifest parity, documentation, generated Codex agents, Codex installer tests and isolated Claude plugin validation pass.
- New CI repeats native discovery without paid model calls.

Companion website change recognizes source declarations and pins per-plugin installation requests to the catalog commit. Native UI stays gated until this source reaches the published branch. Dev first; existing production cooling/approval rules remain in place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791156598&installation_model_id=435537&pr_number=57&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F57&signature=6147fec655fcf9d2c3c886a58c4e49121c77d0ee3fc2f516e25eedf89a788d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->