### PR TITLE
Promote core 1.1.162: secure setup credential entry

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.1.161",
+  "version": "1.1.162",
   "description": "Cross-agent development skills, hooks, orchestration, and native adapters for Claude Code, Codex, Grok Build, and OpenCode",
   "author": {
     "name": "b-open-io",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.1.161",
+  "version": "1.1.162",
   "description": "Cross-agent development skills, hooks, orchestration, and native adapters for Claude Code, Codex, Grok Build, and OpenCode",
   "author": {
     "name": "b-open-io",

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.1.161",
+  "version": "1.1.162",
   "description": "Cross-agent development skills, hooks, orchestration, and native adapters for Claude Code, Codex, Grok Build, and OpenCode",
   "author": {
     "name": "b-open-io",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ manifests share the same release version.
 
 ## Unreleased
 
+## [1.1.162] - 2026-09-04
+
+### Fixed
+
+- Setup plans direct users to enter API keys in their editor, preserving existing settings and keeping secrets out of chat and tool arguments.
+
 ## [1.1.161] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ the plugin detail view; they advertise a skill-owned dashboard or configurator
 without granting capabilities, persisting settings, or requiring the skill to
 own a separate build. This release uses that contract for **Visual Wayfinder**.
 
+Setup plans keep credential values out of chat and tool arguments: enter keys directly in your editor, then verify availability without displaying them.
+
 When Agent Master is launched through Portless with `--agent-master`, it also
 exposes an origin-restricted local broker at
 `https://agent-master.localhost`. Skill pages on bopen.ai can detect that

--- a/skills/setup/scripts/emitter.test.ts
+++ b/skills/setup/scripts/emitter.test.ts
@@ -240,8 +240,11 @@ describe("emitPlan", () => {
 
     const plan = emitPlan(state, selections);
 
-    expect(plan).toContain('export ELEVENLABS_API_KEY="<value supplied securely by the user>"');
+    expect(plan).toContain('export ELEVENLABS_API_KEY="YOUR_API_KEY_HERE"');
     expect(plan).not.toContain("sk-should-never-appear-in-plan");
+    expect(plan).toContain("replace the placeholder directly there");
+    expect(plan).toContain("Never ask for a secret in chat");
+    expect(plan).not.toContain("Ask the user for the secret");
   });
 
   test("identical inputs produce a strictly equal plan", () => {

--- a/skills/setup/scripts/emitter.ts
+++ b/skills/setup/scripts/emitter.ts
@@ -450,9 +450,9 @@ function buildEnvSection(state: HarnessState, selections: PlanSelections): strin
   return selectedChecks(state, selections, "env").map(({ check }) =>
     action(
       `${check.name}: configure the environment key`,
-      `export ${check.name}="<value supplied securely by the user>"`,
-      `test -n "\${${check.name}:-}"`,
-      `${check.obtain ? `Obtain the value from ${check.obtain}. ` : ""}Ask the user for the secret if it is unavailable; never print the value. After confirmation, persist it in the active shell's user profile.`,
+      `# Template for the profile editor; do not execute this placeholder.\nexport ${check.name}="YOUR_API_KEY_HERE"`,
+      `test -n "\${${check.name}:-}" && test "\${${check.name}}" != "YOUR_API_KEY_HERE"`,
+      `${check.obtain ? `Obtain the value from ${check.obtain}. ` : ""}Open the active shell's user profile in the user's editor and have them replace the placeholder directly there. Preserve existing settings and use owner-only file permissions. Never ask for a secret in chat or place its value in a tool argument. Do not read the saved profile back into the conversation. After the user confirms saving, check only whether the key is available; never print it.`,
     ),
   );
 }
@@ -629,9 +629,9 @@ export function emitPlan(state: HarnessState, selections: PlanSelections): strin
     "",
     "## Execution rules",
     "",
-    "1. Execute the sections in order and run every Verify block immediately after its Command block.",
+    "1. Execute sections in order. For credential templates, wait for the user to save in their editor instead of executing the placeholder. Then run the Verify block in a fresh shell that loads the edited profile; never enable shell tracing. For other items, run Verify immediately after Command.",
     "2. Stop the affected item on any command or verification failure, preserve the error output, and continue only with independent items.",
-    "3. Never print secret values. Ask the user when a credential or ask-tier hook write requires confirmation.",
+    "3. Never request or print secret values in chat or tool arguments. Have the user enter credentials directly in their editor. Ask for confirmation of completion or an ask-tier hook write, never for the secret itself.",
     "4. Do not claim success from command exit alone; the corresponding Verify block must pass.",
   ];
 


### PR DESCRIPTION
Promote core 1.1.162 from dev to master. Setup plans now direct users to enter credentials in their editor, keep secrets out of chat and tool arguments, and reject an unfilled placeholder during verification.

Includes merged PR #60. The corresponding Linear Sync fix is published through b-open-io/linear-sync#3.

Closes #2.

Validation: 19 emitter tests, manifest consistency, documentation checks, and isolated plugin extraction/validation passed locally. Follow the repository promotion checks and approval period before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791161614&installation_model_id=435537&pr_number=61&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F61&signature=1907d1ad21bd5caeaf490cd43786cd9949e8038a6256b6c9cf28b5a2a40dfe68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->