### PR TITLE
feat(orchestra): recommend GPT-6 Astra advisor across hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Changed
+
+- Orchestra 0.1.25 / Advisor 0.0.8 recommends `gpt-6-astra` via Codex CLI across Claude Code,
+  Codex, Grok Build, OpenCode, and other shell-capable hosts. The shared lane
+  documents authentication preflight, an explicit read-only sandbox, model
+  overrides, and saved runtime evidence and verdicts.
+
 ## [1.1.162] - 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -825,7 +825,10 @@ does not pin or rename it. The supporting skills divide responsibilities:
   one corrective pass. The main runs the final checks and owns git. Bounded
   implementation defaults to the cheapest authorized capable lane; native
   specialists stay focused on evidence, review, testing, and domain judgment.
-- `advisor` packages a narrow, read-only consult. From a Codex main it can use
+- `advisor` packages a narrow, read-only consult. It recommends `gpt-6-astra`
+  through Codex CLI from Claude Code, Codex, Grok Build, OpenCode, or any host
+  with shell access, with an explicit read-only sandbox and model pin. Override
+  the Codex model with `BOPEN_CODEX_ADVISOR_MODEL`. From a Codex main it can use
   the Claude CLI with the `fable` model-family alias. Override it with
   `BOPEN_ADVISOR_MODEL`. Fable `--safe-mode` appends
   `~/.claude/communication.md` into the system prompt. Missing file is a fail.

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/skills/advisor/SKILL.md
+++ b/modules/orchestra/skills/advisor/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: advisor
-version: 0.0.7
+version: 0.0.8
 description: >-
   Get an independent read-only second opinion at a commitment boundary, before substantive work
   on a hard task, when stuck or changing approach, or at a final review gate. Use for "consult
-  the advisor", "get a second opinion", "ask codex", "ask Fable", "ask opencode", or "ask a bigger model". The
+  the advisor", "get a second opinion", "ask codex", "ask Astra", "ask gpt-6-astra", "ask Fable", "ask opencode", or "ask a bigger model". The
   advisor returns guidance; the main session keeps execution and decision ownership.
 ---
 
@@ -14,6 +14,11 @@ Use an advisor for independent judgment. The advisor never edits, merges,
 commits, ships, or makes the final decision. Use Coordinator for implementation
 workers and Orchestrator when one task combines workers, specialists, and an
 advisor.
+
+For a strong general-purpose advisor, recommend `gpt-6-astra` through the
+Codex CLI from any host with shell access, including Claude Code, Codex,
+Grok Build, and OpenCode. Honor an explicit model or channel preference. See
+[codex-cli.md](references/channels/codex-cli.md) for preflight and dispatch.
 
 ## When to consult
 

--- a/modules/orchestra/skills/advisor/references/channels/README.md
+++ b/modules/orchestra/skills/advisor/references/channels/README.md
@@ -5,10 +5,13 @@ Choose one channel and load only its guide:
 - [native-claude.md](native-claude.md) — Claude's native advisor or a
   read-only premium Claude subagent
 - [fable-cli.md](fable-cli.md) — a clean Claude CLI consult from a Codex main
-- [codex-cli.md](codex-cli.md) — a read-only Codex consult from another host
+- [codex-cli.md](codex-cli.md) — a read-only `gpt-6-astra` consult via Codex CLI from any host,
+  including Codex itself
 - [opencode.md](opencode.md) — a read-only OpenCode subagent consult
 
-Prefer a native advisor when it has the needed evidence. Use a repo-aware
+Recommend `gpt-6-astra` via Codex CLI for strong general-purpose advice when
+that lane is available; the main framework does not restrict this choice.
+Honor explicit preferences for another model or a native advisor. Use a repo-aware
 channel when the advisor must inspect files. If several channels are viable
 and the user has not expressed a preference, recommend one and ask once.
 

--- a/modules/orchestra/skills/advisor/references/channels/codex-cli.md
+++ b/modules/orchestra/skills/advisor/references/channels/codex-cli.md
@@ -1,14 +1,56 @@
-# Codex as advisor
+# Codex CLI as advisor
 
-Use a read-only Codex consult when the decision benefits from a context-clean
-review or direct repository inspection. Bare `codex exec` is read-only by
-default. Do not add write flags. When using a plugin, phrase the task explicitly
-as advisory and no-edits because plugin tasks may otherwise be write-capable.
+Recommend `gpt-6-astra` for a strong, context-clean second opinion on difficult
+decisions and repository reviews. This lane works from Claude Code, Codex,
+Grok Build, OpenCode, or any other framework that can run a shell command.
+A Codex main can launch a separate Codex CLI consult; it need not switch to
+Claude or use its own session model. No Codex plugin or OpenCode provider
+configuration is required for this CLI lane.
 
-Pin the intended model and authentication path, provide the exact checkout or
-worktree, and preserve the complete output. A resumable advisory thread is
-useful for one focused reconciliation; do not create a new cold consult for
-every follow-up.
+## Preflight
 
-Use the advice contract. A run that returns no verdict is a transport failure,
-not approval.
+Check `command -v codex`, `codex --version`, `codex exec --help`, and
+`codex login status`. Confirm the selected authentication/provider path and
+that `gpt-6-astra` is available to that account. An installed CLI alone proves
+neither. Follow the skill's context disclosure rules before sending the consult.
+If authentication or model selection fails, report the failure; never silently
+substitute another model, provider, or billing lane.
+
+## Dispatch
+
+Prepare a standalone consult file with the advice contract, exact checkout,
+and an explicit prohibition on edits. Run the following in Bash; replace the
+absolute paths with the prepared consult, repository, and output locations:
+
+```bash
+set -o pipefail
+CODEX_ADVISOR_MODEL="${BOPEN_CODEX_ADVISOR_MODEL:-gpt-6-astra}"
+PROMPT_FILE="/absolute/path/to/prepared-advisor-consult.md"
+REPO_DIR="/absolute/path/to/repo-or-worktree"
+LOG_FILE="/absolute/path/to/advisor.log"
+VERDICT_FILE="/absolute/path/to/advisor-verdict.md"
+
+codex exec \
+  --model "$CODEX_ADVISOR_MODEL" \
+  --sandbox read-only \
+  --cd "$REPO_DIR" \
+  --output-last-message "$VERDICT_FILE" \
+  - < "$PROMPT_FILE" 2>&1 | tee "$LOG_FILE"
+```
+
+Set `BOPEN_CODEX_ADVISOR_MODEL` only when another Codex model is selected;
+`BOPEN_ADVISOR_MODEL` belongs to the separate Fable lane. Let the selected
+model use its default reasoning effort unless the task or user calls for an
+override supported by the installed CLI and model.
+
+Keep `--sandbox read-only` explicit so a user's write-capable configuration
+does not determine the consult's filesystem permissions. Do not add write or
+sandbox-bypass flags. A sandbox does not constrain external MCP services;
+ensure the consult has no write-capable external tools enabled. If that cannot
+be verified, stop and configure a read-only lane before dispatch.
+
+Preserve the exit status, complete log, and verdict. Verify the actual model
+and provider from CLI runtime metadata, not the advisor's self-description.
+An unavailable model, fallback, nonzero exit, or empty verdict is not approval.
+Use the installed CLI's `codex exec resume --help` for a focused reconciliation
+in the same advisory session, retaining the model pin and read-only boundary.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,12 @@
 # Lessons
 
+## Finish by shipping (2026-09-05)
+
+The user expects completed changes to be validated, committed, pushed, and
+submitted through the repository release flow. Do not stop at an uncommitted
+working-tree edit. Resolve validation dependencies and report the actual
+staging or published status; follow required promotion gates.
+
 ## The user is the author of this repository (2026-08-19)
 
 Do not treat other sessions as other authors. The owner is the author of


### PR DESCRIPTION
Advisor had no GPT-6 Astra guidance. It now recommends `gpt-6-astra` through Codex CLI from Claude Code, Codex, Grok Build, OpenCode, and other hosts with shell access. The shared guide pins the model, explicitly enforces a read-only sandbox, documents authentication and external-tool checks, and preserves runtime evidence and the verdict.

Bumps Advisor to 0.0.8 and both Orchestra manifests to 0.1.25. Updates discovery, README, changelog, and the repository lesson to finish work through the shipping flow.

Validation: documentation checks against origin/dev, paired manifest checks, plugin extraction and strict Claude plugin validation, Bash syntax, reference links, and git diff checks passed. Installed PyYAML in an isolated temporary environment; the generic skill validator passed on a temporary copy with the repository-required top-level version checked separately (the generic validator does not support that extension). Codex isolated installation runs in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175113&installation_model_id=435537&pr_number=62&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F62&signature=b6730cf8d50b33aa3972d376c3aa80709b5138c2ccfb51c51fabcd0362e3925d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->