### PR TITLE
Record lesson: required-checks-expected means branch out of date [OPL-4500]

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -189,3 +189,12 @@ CI is green, and it is merged (or the user explicitly wants to review first).
 Before the final report, run `git log origin/master..HEAD` on every repo
 touched and act on anything it prints. When a PR must wait on checks,
 subscribe to it and keep a check-in scheduled until it merges.
+
+## "Required checks expected" can mean "branch out of date" (2026-09-05)
+
+A 405 merge refusal saying "N of N required status checks are expected" on a
+green PR was a strict up-to-date rule: the base had moved and the checks had
+to re-run on a head containing it. Before blaming rulesets or admin bypass,
+merge the base branch in, let CI re-run, and retry. In a shallow clone, fetch
+the base explicitly (`git fetch origin dev:refs/remotes/origin/dev`); a bare
+`git fetch origin dev` only lands in FETCH_HEAD.


### PR DESCRIPTION
## Problem

A green PR into bopen-ai `dev` was refused with "2 of 2 required status checks are expected" three times, and the first diagnosis blamed ruleset naming or an admin bypass. The real cause was the base branch having moved under a strict up-to-date rule.

## Change

One entry in `tasks/lessons.md`: merge the base in and let CI re-run before suspecting the ruleset, and in a shallow clone fetch the base into an explicit remote ref because a bare fetch lands only in FETCH_HEAD.

Docs only; no plugin surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkUVHPpvFDjVAcQ51bxF3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkUVHPpvFDjVAcQ51bxF3r)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791208149&installation_model_id=435537&pr_number=69&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F69&signature=2e0c7b071c01bca4dc403cdd5b88a1fff7535c6909259eb45ef0062411d33330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->