### PR TITLE
Orchestra 0.1.26: Astra worker + progressive cli-dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ manifests share the same release version.
 
 ## Unreleased
 
+### Changed
+
+- Orchestra 0.1.26 / Advisor 0.0.9 / Coordinator 0.0.18: add Astra
+  (`gpt-6-astra`) as the Codex creative implementation worker (3D / animation /
+  gamification). Split raw `codex exec` recipes into
+  `coordinator/references/workers/cli-dispatch.md`. Advisor cross-links build
+  work to Coordinator and stays read-only. Claude host guide notes auto-mode
+  classifier blocks on Workflow-embedded `codex exec`.
+
+
 ### Added
 
 - `brand-rep:schedule-social-post` 1.0.0 teaches any agent harness without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ manifests share the same release version.
   work to Coordinator and stays read-only. Claude host guide notes auto-mode
   classifier blocks on Workflow-embedded `codex exec`.
 
-
 ### Added
 
 - `brand-rep:schedule-social-post` 1.0.0 teaches any agent harness without

--- a/modules/orchestra/.claude-plugin/plugin.json
+++ b/modules/orchestra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/.codex-plugin/plugin.json
+++ b/modules/orchestra/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestra",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Multi-agent orchestration for Claude Code, Grok, Codex, and OpenCode: worker dispatch, second opinions, wave fan-out, and autonomous loops",
   "author": {
     "name": "b-open-io",

--- a/modules/orchestra/skills/advisor/SKILL.md
+++ b/modules/orchestra/skills/advisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisor
-version: 0.0.8
+version: 0.0.9
 description: >-
   Get an independent read-only second opinion at a commitment boundary, before substantive work
   on a hard task, when stuck or changing approach, or at a final review gate. Use for "consult
@@ -19,6 +19,11 @@ For a strong general-purpose advisor, recommend `gpt-6-astra` through the
 Codex CLI from any host with shell access, including Claude Code, Codex,
 Grok Build, and OpenCode. Honor an explicit model or channel preference. See
 [codex-cli.md](references/channels/codex-cli.md) for preflight and dispatch.
+
+If the user wants Astra or another Codex model to build rather than advise,
+route through Coordinator. Load
+[../coordinator/references/workers/codex.md](../coordinator/references/workers/codex.md).
+Advisor stays read-only; do not dump worker CLI recipes here.
 
 ## When to consult
 

--- a/modules/orchestra/skills/coordinator/SKILL.md
+++ b/modules/orchestra/skills/coordinator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: coordinator
-version: 0.0.17
-description: Route bounded implementation from a capable main session to cheaper workers while keeping planning, review, verification, and git in the main seat. Use for worker dispatch, model arbitrage, parallel implementation, Sol, Luna, Muse, Grok, OpenCode, or native workflows.
+version: 0.0.18
+description: Route bounded implementation from a capable main session to cheaper workers while keeping planning, review, verification, and git in the main seat. Use for worker dispatch, model arbitrage, parallel implementation, Sol, Luna, Astra, Muse, Grok, OpenCode, or native workflows.
 ---
 
 # Coordinator
@@ -26,10 +26,12 @@ Do not read every harness guide. Load only the resources needed for this run:
    [Grok Build](references/hosts/grok.md), or
    [OpenCode](references/hosts/opencode.md).
 3. For each external worker actually selected, read only its guide:
-   [Codex / Sol / Luna](references/workers/codex.md),
+   [Codex / Sol / Luna / Astra](references/workers/codex.md),
    [Grok CLI](references/workers/grok.md),
    [Muse Code](references/workers/muse.md), or
    [OpenCode CLI](references/workers/opencode.md).
+   When dispatching raw Codex CLI, also load
+   [references/workers/cli-dispatch.md](references/workers/cli-dispatch.md).
 
 Example: a Claude main dispatching an OpenCode worker reads this file, the
 dispatch contract, the Claude host guide, and the OpenCode worker guide. It does
@@ -67,11 +69,12 @@ tool- or domain-bound judgment. Match that work against
 when no roster specialist fits. This native-first rule does not apply to routine
 implementation volume.
 
-External quality lanes are Grok and GPT-5.6 Sol. GPT-5.6 Luna at extra-high
-reasoning and Muse Spark 1.3 are cheap-volume choices. OpenCode is a portable
-lane whose provider and model must be pinned. Prefer an already authorized,
-configured cheap lane over a quality lane when both can satisfy the spec.
-Never infer or replace the user's current main model.
+External quality lanes are Grok, GPT-5.6 Sol, and GPT-6 Astra (3D / animation /
+gamification / creative implementation). GPT-5.6 Luna at extra-high reasoning
+and Muse Spark 1.3 are cheap-volume choices. OpenCode is a portable lane whose
+provider and model must be pinned. Prefer an already authorized, configured
+cheap lane over a quality lane when both can satisfy the spec. Never infer or
+replace the user's current main model.
 
 If the work has deterministic stages, loops, or voting, use a native workflow
 only when the current host guide says the primitive exists and the user opted

--- a/modules/orchestra/skills/coordinator/references/hosts/claude.md
+++ b/modules/orchestra/skills/coordinator/references/hosts/claude.md
@@ -36,9 +36,18 @@ main is only the fallback when native child dispatch is unavailable.
 Load only the selected worker guide:
 
 - [Grok CLI](../workers/grok.md)
-- [Codex, Sol, or Luna](../workers/codex.md)
+- [Codex, Sol, Luna, or Astra](../workers/codex.md)
 - [Muse Code](../workers/muse.md)
 - [OpenCode CLI](../workers/opencode.md)
+
+### Auto-mode and Workflow embedding
+
+Claude Code's auto-mode classifier can block embedding `codex exec` (or other
+external CLI workers) inside Workflow scripts. When that happens, do not fight
+the classifier by encoding, renaming, or smuggling the command. Drive the Codex
+lane from the main session or from a native controller subagent that supervises
+the CLI outside the Workflow script body. Workflow remains fine for Claude-native
+agent/pipeline/parallel stages; external vendor CLIs stay supervised shell lanes.
 
 Do not assume an external CLI has the same tools, plugin context, filesystem
 permissions, or model as the Claude main. Apply the shared dispatch contract and

--- a/modules/orchestra/skills/coordinator/references/workers/cli-dispatch.md
+++ b/modules/orchestra/skills/coordinator/references/workers/cli-dispatch.md
@@ -1,0 +1,70 @@
+# Codex CLI dispatch
+
+Load this only when dispatching raw `codex exec` for a Sol, Luna, or Astra
+worker. Prefer a Claude Code Codex plugin's resumable job interface when it is
+installed and suitable.
+
+## Capture and resume
+
+Always capture the final message and structured events:
+
+- `--output-last-message <path>` — write the last agent message to a file
+- `--json` — emit JSONL events on stdout for monitoring
+- `codex exec resume <session>` — continue the same session with a follow-up
+
+Redirect the full stream to a log. Demand the shared final report. Verify the
+actual model and effort from runtime metadata, not the worker's self-description.
+
+## Network in the sandbox
+
+Default is no extra network config. When the worker must run `bun add` (or
+similar package installs) inside `workspace-write`, add:
+
+    -c sandbox_workspace_write.network_access=true
+
+Do not make that the default. Prefer specs that avoid in-sandbox installs when
+possible.
+
+## Example commands
+
+Sol:
+
+    codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-sol \
+      -c model_reasoning_effort="high" \
+      --json --output-last-message /tmp/dispatch-<id>-last.md \
+      "<imperative; details in SPEC file>" \
+      > /tmp/dispatch-<id>.log 2>&1 &
+
+Luna:
+
+    codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-luna \
+      -c model_reasoning_effort="xhigh" \
+      --json --output-last-message /tmp/dispatch-<id>-last.md \
+      "<imperative; details in SPEC file>" \
+      > /tmp/dispatch-<id>.log 2>&1 &
+
+If Luna rejects `xhigh`, try `max` once and report which effort actually ran.
+Luna without `xhigh` or `max` is not this lane.
+
+Astra:
+
+    codex exec --sandbox workspace-write --cd <repo> -m gpt-6-astra \
+      -c model_reasoning_effort="high" \
+      --json --output-last-message /tmp/dispatch-<id>-last.md \
+      "<imperative; details in SPEC file>" \
+      > /tmp/dispatch-<id>.log 2>&1 &
+
+Astra has no silent effort fallback. Raise to `xhigh` or `max` only when the
+user asks or the first `high` run fails; report the effort that actually ran.
+
+With network for installs (any of the three), insert before the prompt:
+
+    -c sandbox_workspace_write.network_access=true
+
+## Sandbox caveats
+
+Codex sandboxes can differ from the main environment in network, ports, and
+caches. Diffs produced under sandbox constraints may not match a clean main
+checkout. Do not accept build-tool substitutions, dependency shims, or removed
+assets as fixes for those constraints. Re-verify acceptance unpiped in the main
+environment.

--- a/modules/orchestra/skills/coordinator/references/workers/cli-dispatch.md
+++ b/modules/orchestra/skills/coordinator/references/workers/cli-dispatch.md
@@ -12,6 +12,8 @@ Always capture the final message and structured events:
 - `--json` — emit JSONL events on stdout for monitoring
 - `codex exec resume <session>` — continue the same session with a follow-up
 
+For Coordinator’s one corrective re-dispatch, prefer `codex exec resume` with the same model pin and sandbox rather than starting a fresh session.
+
 Redirect the full stream to a log. Demand the shared final report. Verify the
 actual model and effort from runtime metadata, not the worker's self-description.
 

--- a/modules/orchestra/skills/coordinator/references/workers/codex.md
+++ b/modules/orchestra/skills/coordinator/references/workers/codex.md
@@ -1,4 +1,4 @@
-# Codex, Sol, and Luna Worker
+# Codex, Sol, Luna, and Astra Worker
 
 Read this only when a separate Codex CLI process is the selected worker.
 Normally this is an external lane from Claude, Grok, or OpenCode. From a Codex
@@ -7,17 +7,23 @@ Codex process when it is the chosen cheaper or isolated implementation lane.
 
 ## Choose the model
 
-- GPT-5.6 Sol is the quality Codex worker.
-- GPT-5.6 Luna at extra-high reasoning is the cheap, unlimited-feeling volume
-  lane. Prefer it for routine implementation when it meets the acceptance
-  criteria, but never replace a lane the user explicitly selected.
+- **Sol** (`gpt-5.6-sol`, reasoning `high`) — quality Codex worker.
+- **Luna** (`gpt-5.6-luna`, reasoning `xhigh`) — cheap volume lane. Prefer it
+  for routine implementation when it meets acceptance criteria; never replace a
+  user-selected lane.
+- **Astra** (`gpt-6-astra`, recommended `high`) — 3D / animation / gamification /
+  creative implementation lane. Use `xhigh` or `max` only if the user asks or
+  the first `high` run fails.
 
-Both send the prompt, spec, and selected repository content to OpenAI. Apply
-the Coordinator disclosure rule before first use.
+Advisor Astra (`gpt-6-astra` under Advisor) is not this worker. Read-only
+second opinions stay in Advisor; implementation stays here.
+
+All three send the prompt, spec, and selected repository content to OpenAI.
+Apply the Coordinator disclosure rule before first use.
 
 ## Preflight
 
-Confirm the codex binary, authentication, selected model, effective sandbox,
+Confirm the `codex` binary, authentication, selected model, effective sandbox,
 and reasoning effort. If a Claude Code Codex plugin is installed, prefer its
 resumable background job interface; otherwise use the raw CLI. Do not assume
 the plugin and raw CLI share model, profile, or sandbox settings.
@@ -27,27 +33,8 @@ the user approves the machine-level change.
 
 ## Raw CLI
 
-Sol:
-
-    codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-sol \
-      -c model_reasoning_effort="high" \
-      "<imperative; details in SPEC file>" \
-      > /tmp/dispatch-<id>.log 2>&1 &
-
-Luna:
-
-    codex exec --sandbox workspace-write --cd <repo> -m gpt-5.6-luna \
-      -c model_reasoning_effort="xhigh" \
-      "<imperative; details in SPEC file>" \
-      > /tmp/dispatch-<id>.log 2>&1 &
-
-If Luna rejects xhigh, try max once and report which effort actually ran. Luna
-without extra-high or max is not this lane. Capture complete output and demand
-the shared final report.
-
-Codex sandboxes can differ from the main environment in network, ports, and
-caches. Do not accept build-tool substitutions, dependency shims, or removed
-assets as fixes for those constraints.
+When dispatching raw `codex exec`, also read
+[cli-dispatch.md](cli-dispatch.md). Do not inline long CLI recipes here.
 
 The orchestra claudex skill replaces the main seat with Claude Code routed to
 Sol. It is not a worker and must not be used as one.


### PR DESCRIPTION
## Summary
- Kayle applied Zack seating drafts for Orchestra 0.1.26 / Advisor 0.0.9 / Coordinator 0.0.18
- Astra (`gpt-6-astra`) added as Codex creative implementation worker (3D / animation / gamification)
- Raw `codex exec` recipes progressive-loaded via `cli-dispatch.md`; Advisor stays read-only
- Claude host guide notes auto-mode classifier blocks on Workflow-embedded `codex exec`

## Ask
Zack: please do a prompt-quality review of the seating drafts.

## Test plan
- [ ] Advisor has no raw CLI recipes (`output-last-message`, `bun add`)
- [ ] `cli-dispatch.md` contains `--output-last-message`, `--json`, `sandbox_workspace_write.network_access`
- [ ] `workers/codex.md` progressive-loads `cli-dispatch`
- [ ] Both orchestra plugin manifests are `0.1.26`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791253585&installation_model_id=435537&pr_number=70&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F70&signature=904568284b5075d12c4d432594fe8c13a92d3c95f957b0bd9199a6aa2b8fba3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->