### PR TITLE
docs: changelog entry for restraint skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ manifests share the same release version.
 
 ### Added
 
+- New skill `restraint` 0.1.0: YAGNI with a governor for any coding task — write
+  the least code that is still the right code. Ladder (required-or-speculative,
+  reuse, stdlib/native, installed dep, smallest correct change with the UI and
+  trust-boundary guard inside the rung), levels `off | lite | full (default) |
+  ultra` via `/restraint`, no in-code marker comments. Triggers on "restraint",
+  "don't over-build", "yagni", and bloat/boilerplate complaints.
 - Ada (native-desktop) 1.1.0: wire `apple-xcode-build-loop`; document OpenAI `build-macos-apps` + twostraws Swift skill pointers for non–Native-SDK Swift work.
 - Kira (mobile) 1.2.0: wire `apple-xcode-build-loop`; native Swift path points at OpenAI `build-ios-apps` + twostraws pros without abandoning Expo-first.
 - New skill `apple-xcode-build-loop`: Makefile + xcodebuild + xcbeautify + warnings-as-errors + simulator/SPM gates (AppCreator-inspired; not a copy).


### PR DESCRIPTION
Adds the missing CHANGELOG.md entry for the new restraint skill so the dev-to-master promotion gate (check-docs release gate) passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791302432&installation_model_id=435537&pr_number=76&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F76&signature=28e64e413c2def404a8f2af2cb1b86ea117874fba9e1e7ea9c3b1f7d1c743a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->