### PR TITLE
docs: mark bsv-mcp shipped in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ manifests share the same release version.
 
 ### Changed
 
+- CLAUDE.md: mark **bsv-mcp** as shipped (npm `bsv-mcp`, https://bsvmcp.com/docs; wallet, explorer, ordinals via MCP Apps). `agent-master` and `gib` remain WIP.
 - humanize 1.0.13 → **1.0.14**: rename check 5 heading to **Mannered prose**.
 - humanize 1.0.12 → **1.0.13**: Core editorial check **Reject mannered prose** (Anthropic block seated verbatim; no separate mannered-prose skill).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ When users ask to see what changed, use `Skill(review:visual-review)` — it tur
 - **BigBlocks**: Bitcoin component library
 - **Sigma Identity**: OAuth 2.0 authentication system (auth.sigmaidentity.com)
 - **agent-master**: MCP server coordination (WIP)
-- **bsv-mcp**: Blockchain functionality exposure (WIP)  
+- **bsv-mcp**: Bitcoin SV MCP server (npm `bsv-mcp`, docs https://bsvmcp.com/docs) — wallet, explorer, ordinals via MCP Apps
 - **gib**: Git + blockchain version control (WIP)
 
 ## Command Management


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Marks **bsv-mcp** as shipped in the "Our Projects (Referenced in Prompts)" list.

Replaces the WIP blurb with the published npm package, docs URL, and MCP Apps capabilities (wallet, explorer, ordinals).

`agent-master` and `gib` stay WIP. The Project Context bullet that already names bsv-mcp is unchanged.

`CHANGELOG.md` has a one-line Unreleased note because `scripts/check-docs.py` treats `CLAUDE.md` as plugin content. README inventory was not required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-609b6683-fc64-4c57-89b5-245aec9fdb20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-609b6683-fc64-4c57-89b5-245aec9fdb20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/b-open-io/codesmith/prompts/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791549902&installation_model_id=435537&pr_number=79&repository=b-open-io%2Fprompts&return_to=https%3A%2F%2Fgithub.com%2Fb-open-io%2Fprompts%2Fpull%2F79&signature=4ddfb544f4ee15e1b63f1ce96ee89bddf8bcf384a1d367e6e1f925f83b5ee31a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->